### PR TITLE
Refactor ProxyFix configuration with environment variable

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -565,7 +565,14 @@ app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'default-dev-key-change-
 
 # Apply ProxyFix to handle headers from a reverse proxy (like Nginx or Caddy)
 # This is crucial for request.is_secure to work correctly behind an SSL-terminating proxy.
-app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+trusted_proxy_hops = int(os.environ.get('TRUSTED_PROXY_HOPS', '1'))
+app.wsgi_app = ProxyFix(
+    app.wsgi_app, 
+    x_for=trusted_proxy_hops, 
+    x_proto=trusted_proxy_hops, 
+    x_host=trusted_proxy_hops, 
+    x_prefix=trusted_proxy_hops
+)
 
 # --- Secure Session Cookie Configuration ---
 # For local network usage, disable secure cookies to allow HTTP connections


### PR DESCRIPTION
Make ProxyFix trusted proxy hops configurable

Fixes CSRF token validation issues when accessing speakr from external networks by making the number of trusted proxy hops configurable via the TRUSTED_PROXY_HOPS environment variable.

Problem:
- CSRF validation was failing for external requests
- ProxyFix was hardcoded to trust only 1 proxy hop (x_for=1)
- Real infrastructure might have 2 or 3 proxy hops

Solution:
- Add TRUSTED_PROXY_HOPS environment variable (default: 1)
- Apply same hop count to all ProxyFix parameters (x_for, x_proto, x_host, x_prefix)
- Maintains backward compatibility with default value
- Allows proper configuration for different deployment environments

Deployment:
Set TRUSTED_PROXY_HOPS=2 (or 3) in Kubernetes production environment to account for the full proxy chain in the homelab infrastructure.