### PR TITLE
Fix PostgreSQL support and update configuration examples

### DIFF
--- a/config/env.asr.example
+++ b/config/env.asr.example
@@ -183,5 +183,8 @@ SUMMARY_QUEUE_WORKERS=2
 JOB_MAX_RETRIES=3
 
 # --- Docker Settings (rarely need to be changed) ---
+# Database URI - SQLite (default) or PostgreSQL
 SQLALCHEMY_DATABASE_URI=sqlite:////data/instance/transcriptions.db
+# For PostgreSQL, use: postgresql://username:password@hostname:5432/database_name
+# Example: postgresql://speakr:password@postgres:5432/speakr
 UPLOAD_FOLDER=/data/uploads

--- a/config/env.whisper.example
+++ b/config/env.whisper.example
@@ -185,5 +185,8 @@ SUMMARY_QUEUE_WORKERS=2
 JOB_MAX_RETRIES=3
 
 # --- Docker Settings (rarely need to be changed) ---
+# Database URI - SQLite (default) or PostgreSQL
 SQLALCHEMY_DATABASE_URI=sqlite:////data/instance/transcriptions.db
+# For PostgreSQL, use: postgresql://username:password@hostname:5432/database_name
+# Example: postgresql://speakr:password@postgres:5432/speakr
 UPLOAD_FOLDER=/data/uploads

--- a/config/env.whisperx.example
+++ b/config/env.whisperx.example
@@ -195,5 +195,8 @@ SUMMARY_QUEUE_WORKERS=2
 JOB_MAX_RETRIES=3
 
 # --- Docker Settings (rarely need to be changed) ---
+# Database URI - SQLite (default) or PostgreSQL
 SQLALCHEMY_DATABASE_URI=sqlite:////data/instance/transcriptions.db
+# For PostgreSQL, use: postgresql://username:password@hostname:5432/database_name
+# Example: postgresql://speakr:password@postgres:5432/speakr
 UPLOAD_FOLDER=/data/uploads

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -262,6 +262,19 @@ mkdir -p auto-process
 chmod 755 auto-process
 ```
 
+#### Using PostgreSQL Instead of SQLite
+
+By default, Speakr uses SQLite for its database, which is perfect for most installations and requires no additional setup.
+However, if you need the scalability and concurrent access capabilities of PostgreSQL, Speakr fully supports it.
+
+**Configuration:**
+
+To use PostgreSQL, set the `SQLALCHEMY_DATABASE_URI` environment variable in your `.env` file:
+
+```bash
+SQLALCHEMY_DATABASE_URI=postgresql://username:password@hostname:5432/database_name
+```
+
 ### Step 7: Launch Speakr
 
 With everything configured, you're ready to start Speakr. The `-d` flag runs the container in detached mode, meaning it continues running in the background:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ numpy==1.24.3
 sentence-transformers==2.7.0
 scikit-learn==1.3.0
 huggingface-hub>=0.19.0
+psycopg2-binary>=2.9.0


### PR DESCRIPTION
Add PostgreSQL support by including `psycopg2-binary` dependency in requirements.txt. The application code already supported PostgreSQL, but the required driver was missing - this PR adds the dependency and updates documentation with PostgreSQL configuration examples.