### PR TITLE
declare token vars earlier

### DIFF
--- a/templates/account.html
+++ b/templates/account.html
@@ -2723,7 +2723,11 @@ curl "https://your-speakr-instance.com/api/recordings?token=YOUR_TOKEN_HERE"</co
             // Load speakers for the Speakers Management tab
             let speakersTabData = [];
             let speakersTabLoaded = false;
-            
+
+            // API Tokens tab variables
+            let tokensData = [];
+            let tokensTabLoaded = false;
+
             async function loadSpeakersTab() {
                 // Don't reload if already loaded
                 if (speakersTabLoaded) return;
@@ -5350,10 +5354,6 @@ curl "https://your-speakr-instance.com/api/recordings?token=YOUR_TOKEN_HERE"</co
                 localStorage.setItem('preferredLanguage', newUILanguage);
             }
         });
-
-        // API Tokens Management Functions
-        let tokensData = [];
-        let tokensTabLoaded = false;
 
         async function loadTokensTab() {
             if (tokensTabLoaded) return;


### PR DESCRIPTION
This fixes an issue where if a user clicks the tokens tab, JavaScript would throw the following error because the variables weren't initialized yet. This would result in the tokens never being displayed in the API Tokens tab.

```
Uncaught (in promise) ReferenceError: can't access lexical declaration 'tokensTabLoaded' before initialization
    loadTokensTab https://recordings.redacted.net/account:5390
    switchToTab https://recordings.redacted.net/account:2656
    showTokensTab https://recordings.redacted.net/account:2695
    <anonymous> https://recordings.redacted.net/account:2746
    EventListener.handleEvent* https://recordings.redacted.net/account:2744
    async* https://recordings.redacted.net/account:2310
```