### PR TITLE
Additional upload values, title generation override, and summary prompt substitutions.

### DIFF
--- a/src/api/recordings.py
+++ b/src/api/recordings.py
@@ -2028,6 +2028,21 @@ def upload_file():
         # Get notes from the form
         notes = request.form.get('notes')
 
+        # Parse special SOURCE block in notes (if present) to extract JSON metadata
+        source_json = None
+        if notes:
+            try:
+                m = re.search(r"SOURCE(.*?)ENDSOURCE", notes, re.S | re.IGNORECASE)
+                if m:
+                    content = m.group(1).strip()
+                    try:
+                        source_json = json.loads(content)
+                        current_app.logger.info(f"Parsed SOURCE JSON from notes for upload: keys={list(source_json.keys())}")
+                    except Exception as e:
+                        current_app.logger.warning(f"Failed to parse SOURCE JSON from notes: {e}")
+            except Exception:
+                source_json = None
+
         # Get file's lastModified timestamp from client (milliseconds since epoch)
         file_last_modified = request.form.get('file_last_modified')
 
@@ -2118,7 +2133,6 @@ def upload_file():
                 max_speakers = int(ASR_MAX_SPEAKERS)
             except (ValueError, TypeError):
                 max_speakers = None
-
         # Fall back to user's default transcription language if still not set
         if not language and current_user.transcription_language:
             language = current_user.transcription_language
@@ -2127,8 +2141,26 @@ def upload_file():
         # Create initial database entry
         now = datetime.utcnow()
 
-        # Determine meeting_date: prefer client-provided lastModified, then file metadata, then current time
+        # Determine meeting_date: prefer client-provided source JSON, then lastModified, then file metadata, then current time
         meeting_date = None
+        uploaded_title = None
+        # If SOURCE JSON provides a meeting_date, prefer that (highest priority)
+        if source_json and isinstance(source_json, dict):
+            if source_json.get('meeting_date'):
+                md_val = source_json.get('meeting_date')
+                try:
+                    meeting_date = datetime.fromisoformat(md_val.replace('Z', '+00:00'))
+                    current_app.logger.info(f"Using meeting_date from SOURCE JSON: {meeting_date}")
+                except Exception:
+                    try:
+                        meeting_date = datetime.strptime(md_val, '%Y-%m-%d %H:%M:%S')
+                        current_app.logger.info(f"Using meeting_date from SOURCE JSON (strptime fallback): {meeting_date}")
+                    except Exception as e:
+                        current_app.logger.warning(f"Could not parse meeting_date from SOURCE JSON '{md_val}': {e}")
+
+            if source_json.get('title'):
+                uploaded_title = source_json.get('title')
+                current_app.logger.info(f"Using title from SOURCE JSON: {uploaded_title}")
 
         # First try client-provided file lastModified (most reliable for uploads)
         if file_last_modified:
@@ -2150,11 +2182,14 @@ def upload_file():
         if not meeting_date:
             meeting_date = now
             current_app.logger.debug("No file date available, using current time")
+        
+        # Use uploaded title from SOURCE JSON if available, otherwise default to "Recording - original_filename"
+        title = uploaded_title if uploaded_title else f"Recording - {original_filename}"
 
         recording = Recording(
             audio_path=filepath,
             original_filename=original_filename,
-            title=f"Recording - {original_filename}",
+            title=title,
             file_size=final_file_size,
             status='PENDING',
             meeting_date=meeting_date,

--- a/src/tasks/processing.py
+++ b/src/tasks/processing.py
@@ -228,6 +228,18 @@ def generate_title_task(app_context, recording_id, will_auto_summarize=False):
             if naming_template:
                 current_app.logger.info(f"Using user's default naming template '{naming_template.name}' for recording {recording_id}")
 
+        # If a title already exists (e.g., uploaded via notes), do NOT overwrite it.
+        if recording.title and recording.title.strip():
+            current_app.logger.info(
+                f"Recording {recording_id} already has a title; preserving uploaded title and skipping AI/title-template generation."
+            )
+            # Ensure status is set correctly when not auto-summarizing
+            if not will_auto_summarize:
+                recording.status = 'COMPLETED'
+                recording.completed_at = datetime.utcnow()
+            db.session.commit()
+            return
+
         # Check if we need to generate AI title
         needs_ai_title = naming_template is None or naming_template.needs_ai_title()
 
@@ -517,6 +529,28 @@ def generate_summary_only_task(app_context, recording_id, custom_prompt_override
 - **Key Decisions Made**: A bulleted list of any decisions reached
 - **Action Items**: A bulleted list of tasks assigned, including who is responsible if mentioned"""
                 current_app.logger.info(f"Using hardcoded default prompt for recording {recording_id}")
+        # Allow substitution placeholders in the chosen summary prompt.
+        # Supported placeholders: {{meeting_date}}, {{title}} (whitespace inside braces allowed)
+        try:
+            def _subst(text, name, val):
+                return re.sub(r"\{\{\s*" + re.escape(name) + r"\s*\}\}", val or "", text)
+
+            # Format meeting_date reasonably for prompts
+            if recording.meeting_date:
+                try:
+                    meeting_date_str = recording.meeting_date.isoformat()
+                except Exception:
+                    meeting_date_str = str(recording.meeting_date)
+            else:
+                meeting_date_str = ""
+
+            title_str = recording.title or ""
+
+            summarization_instructions = _subst(summarization_instructions, 'meeting_date', meeting_date_str)
+            summarization_instructions = _subst(summarization_instructions, 'title', title_str)
+        except Exception as e:
+            current_app.logger.warning(f"Failed to substitute placeholders in summary prompt for recording {recording_id}: {e}")
+        
 
         # Build context information
         current_date = datetime.now().strftime("%B %d, %Y")

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -202,6 +202,8 @@
     "defaultPromptInfo": "This default prompt will be used for all users who haven't set their own custom prompt in their account settings.",
     "defaultPrompts": "Default Prompts",
     "defaultSummarizationPrompt": "Default Summarization Prompt",
+    "defaultPromptFieldsTitle": "Available placeholders:",
+    "defaultPromptFieldsDesc": "You can use placeholders in the prompt text that will be substituted when processing a recording. Supported placeholders: {{meeting_date}} (replaced with the recording's meeting date in ISO 8601 format) and {{title}} (replaced with the recording title). Placeholders can be used anywhere in the prompt and will be replaced before the prompt is sent to the LLM.",
     "editUser": "Edit User",
     "email": "EMAIL",
     "emailLabel": "Email",

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -718,6 +718,11 @@
                                 class="w-full px-3 py-2 border border-[var(--border-secondary)] rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--border-focus)] bg-[var(--bg-input)] text-[var(--text-primary)]"
                                 :placeholder="t('form.summaryPromptPlaceholder')">
                             </textarea>
+                            <p class="text-sm text-[var(--text-muted)] mt-2">
+                                <strong>${t('adminDashboard.defaultPromptFieldsTitle')}</strong>
+                                <br>
+                                ${t('adminDashboard.defaultPromptFieldsDesc')}
+                            </p>
                         </div>
                         
                         <div class="flex justify-between items-center">


### PR DESCRIPTION
This PR is an example of some changes needed for the following use case.

In general, Speakr is being used as a transcription service for existing Youtube videos, and a library and API endpoint for another application. Items like existing titles and meeting dates are not being transferred on upload and lack of correct data is causing lack of context for processes like summarizing.

**Data from existing content**
The current upload API assumes a file to process will be completely handled by Speakr including items like title generation and meeting date
In the case of our existing content (years of Youtube presentations to educate our community), the title and recording date are already known.  The title was created to both advertise and track usage on Youtube.  We need it to match the value in Speakr.

To get around this the 'notes' field was used to pass a stringified JSON object with specific delimiters. This data was then parsed and used to supply values to 'title' and 'meeting_date'.  Additional values were passed (such as an external record id) to allow retrieval and verification by calling a /recording/x/notes API.

Sample text in notes field.
```
SOURCE{“source_id”:3,”youtube_id”:”Tdryy7Aw9fE”,”title”:”Daily Call 2/3/23 with Guest Speaker Craig Palmer, CEO of MakersPlace”,”meeting_date”:”2023-02-03T07:00:00.000Z”,”privacy_status”:”private”}ENDSOURCE
```

**Title generation**
If the title was uploaded the auto generation of a title is skipped.

**Summary Prompt Substitution**
When generating the summary the process was continually assuming the date of the meeting was the upload date instead of the the actual date (in some cases 3 years ago). Also the summarizing had difficulty sometimes determining the primary presenter.

The only way I could find to give the Summary some context was to include the actual meeting date and title as substitution in the Prompt.

**Thoughts**
Ideally the title and meeting date fields would be available in the upload API.  It would also be helpful to have some sort of metadata that could be used by external applications to track things like ids or external status for other systems.

I did not want to make changes to the database in a PR so created these workarounds.  There may be much better ways of handling these features.  And they could be more flexible (like a configurable delimiter).

I don't expect this PR to be included 'as-is', they are more for ideas and discussion on the best way to implement.  But I could certainly tweak these if they look like they are valuable to the application and don't break other current or future features. 
