### PR TITLE
Set an XHR upload timeout so a stalled upload fails into the recovery path

### DIFF
--- a/static/js/modules/composables/upload.js
+++ b/static/js/modules/composables/upload.js
@@ -6,6 +6,7 @@
 import * as FailedUploads from '../db/failed-uploads.js';
 import * as IncognitoStorage from '../db/incognito-storage.js';
 import * as RecordingDB from '../db/recording-persistence.js';
+import { computeUploadTimeout } from '../utils/upload-timeout.js';
 
 // Parse error message and return friendly error info
 function getFriendlyError(errorMessage, t) {
@@ -588,6 +589,13 @@ export function useUpload(state, utils) {
 
                 xhr.onerror = () => reject(new Error('Network error during upload'));
                 xhr.ontimeout = () => reject(new Error('Upload timed out'));
+
+                // Without an explicit timeout, a stalled connection (no FIN/RST,
+                // just no progress) hangs forever and ontimeout never fires — so
+                // the upload never reaches the catch block that persists the file
+                // for retry / triggers the local-download fallback. Set a
+                // size-scaled ceiling so a stalled upload eventually fails over.
+                xhr.timeout = computeUploadTimeout(fileItem.file?.size || 0);
 
                 // Store abort controller on item for cancellation
                 fileItem._xhr = xhr;

--- a/static/js/modules/utils/upload-timeout.js
+++ b/static/js/modules/utils/upload-timeout.js
@@ -1,0 +1,42 @@
+/**
+ * Upload timeout calculation.
+ *
+ * XMLHttpRequest has no timeout by default (xhr.timeout === 0), so a TCP
+ * connection that stalls mid-stream — no FIN, no RST, just no progress — sits
+ * open indefinitely and neither onerror nor ontimeout ever fires. The upload
+ * then never reaches the catch block that persists the file to IndexedDB /
+ * triggers the local-download fallback, so a stalled upload is a silent
+ * data-loss path. We set an explicit, size-scaled ceiling so a stalled upload
+ * eventually fails over into that recovery path instead of hanging forever.
+ */
+
+const MINUTE_MS = 60 * 1000;
+
+// Floor for any upload, regardless of size.
+const BASE_TIMEOUT_MS = 10 * MINUTE_MS;
+
+// Additional allowance per 10 MB of payload, so large recordings that simply
+// take a long time to transfer over a slow link are not killed prematurely.
+const MS_PER_10MB = 1 * MINUTE_MS;
+
+const BYTES_PER_10MB = 10 * 1024 * 1024;
+
+/**
+ * Compute the XHR timeout (in milliseconds) for an upload of the given size.
+ * @param {number} fileSizeBytes - size of the file being uploaded, in bytes.
+ * @returns {number} timeout in milliseconds (always >= BASE_TIMEOUT_MS).
+ */
+export function computeUploadTimeout(fileSizeBytes) {
+    const size = Number(fileSizeBytes);
+    if (!Number.isFinite(size) || size <= 0) {
+        return BASE_TIMEOUT_MS;
+    }
+    return Math.round(BASE_TIMEOUT_MS + (size / BYTES_PER_10MB) * MS_PER_10MB);
+}
+
+export const UPLOAD_TIMEOUT_CONSTANTS = Object.freeze({
+    MINUTE_MS,
+    BASE_TIMEOUT_MS,
+    MS_PER_10MB,
+    BYTES_PER_10MB,
+});

--- a/static/js/modules/utils/upload-timeout.test.js
+++ b/static/js/modules/utils/upload-timeout.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { computeUploadTimeout, UPLOAD_TIMEOUT_CONSTANTS } from './upload-timeout.js';
+
+const { BASE_TIMEOUT_MS, MINUTE_MS, BYTES_PER_10MB } = UPLOAD_TIMEOUT_CONSTANTS;
+
+describe('computeUploadTimeout', () => {
+    it('returns the base floor for an empty or zero-size upload', () => {
+        expect(computeUploadTimeout(0)).toBe(BASE_TIMEOUT_MS);
+    });
+
+    it('falls back to the base floor for invalid sizes', () => {
+        expect(computeUploadTimeout(undefined)).toBe(BASE_TIMEOUT_MS);
+        expect(computeUploadTimeout(null)).toBe(BASE_TIMEOUT_MS);
+        expect(computeUploadTimeout(NaN)).toBe(BASE_TIMEOUT_MS);
+        expect(computeUploadTimeout(-5)).toBe(BASE_TIMEOUT_MS);
+    });
+
+    it('adds one minute per 10 MB on top of the base floor', () => {
+        // 10 MB -> base + 1 minute
+        expect(computeUploadTimeout(BYTES_PER_10MB)).toBe(BASE_TIMEOUT_MS + MINUTE_MS);
+        // 100 MB -> base + 10 minutes
+        expect(computeUploadTimeout(10 * BYTES_PER_10MB)).toBe(BASE_TIMEOUT_MS + 10 * MINUTE_MS);
+    });
+
+    it('scales monotonically with size and never drops below the floor', () => {
+        const small = computeUploadTimeout(1 * 1024 * 1024); // 1 MB
+        const large = computeUploadTimeout(500 * 1024 * 1024); // 500 MB
+        expect(small).toBeGreaterThanOrEqual(BASE_TIMEOUT_MS);
+        expect(large).toBeGreaterThan(small);
+    });
+
+    it('gives a multi-hour recording a sane (not infinite) ceiling', () => {
+        // ~300 MB recording: base 10 min + 30 min = 40 min, well under an hour.
+        const fortyMinutes = 40 * MINUTE_MS;
+        expect(computeUploadTimeout(300 * 1024 * 1024)).toBe(fortyMinutes);
+    });
+});


### PR DESCRIPTION
## Symptom

A browser recording or file upload that stalls mid-transfer hangs forever. The connection drops to zero throughput without closing (flaky network, laptop sleep/resume, an idle proxy holding the socket); the progress bar sticks, the UI shows no error, and the upload never completes or fails. v0.9.0 keeps the local copy until the server confirms, so the audio survives, but the user has to spot the stuck upload and reload to get it back.

## Root cause

`upload.js` builds the upload with `XMLHttpRequest` for progress events. It wires `xhr.ontimeout` but never sets `xhr.timeout`, which defaults to `0` (no timeout). A stalled socket then fires neither `ontimeout` nor `onerror`, so the upload never reaches the `catch` that saves the file to IndexedDB and triggers the download fallback from #287 / #297. A silent stall skips the whole recovery path.

## Fix

- New `static/js/modules/utils/upload-timeout.js`: `computeUploadTimeout(size)` returns a 10-minute floor plus 1 minute per 10 MB, so a large recording gets room to transfer while a stall still fails within a bounded time.
- `upload.js` sets `xhr.timeout = computeUploadTimeout(fileItem.file?.size)` before `send()`. The existing `ontimeout` handler rejects, so a stall now follows the same failure and recovery path as any other upload error.

The helper takes no browser globals, so it unit-tests in the current node test environment.

## Tests

Added `static/js/modules/utils/upload-timeout.test.js` (vitest): base floor, invalid-size fallback, per-10 MB scaling, monotonicity, and a multi-hour recording ceiling. `npm test`: 56 passing across 4 files.

## Notes

- This sits beside #302 (CSRF-token-expiry retry on the same XHR path): a separate long-recording failure mode with the same goal. Both touch `upload.js`, and the edits do not overlap.
- It also backs the #287 / #297 work by making sure a stalled upload reaches the recovery path you added.
- I have read CONTRIBUTING.md and CLA.md, and I agree to the terms of the CLA.
