### PR TITLE
Warn before leaving the page while an upload is still in flight

### DIFF
--- a/static/js/app.modular.js
+++ b/static/js/app.modular.js
@@ -3680,6 +3680,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                         e.returnValue = ''; // Chrome requires this
                         return 'You have an unsaved recording. Are you sure you want to leave?';
                     }
+                    // Check for uploads still in flight. A freshly-recorded file
+                    // may still be mid-transfer with no copy on the server yet;
+                    // leaving now risks losing it. (Items that already reached
+                    // 'pending'/'failed' are on the server or saved for retry.)
+                    const uploadsInFlight = uploadQueue.value.some(item =>
+                        item.status === 'queued' || item.status === 'ready' || item.status === 'uploading');
+                    if (uploadsInFlight) {
+                        e.preventDefault();
+                        e.returnValue = ''; // Chrome requires this
+                        return 'Uploads are still in progress. Leaving now may lose recordings that have not finished uploading.';
+                    }
                     // Check for incognito recording that would be lost
                     // Only warn if we're currently viewing the incognito recording
                     // (if user navigated away, they've implicitly abandoned it or already been warned)


### PR DESCRIPTION
## Symptom

Closing or reloading the tab during an upload interrupts it with no warning. v0.9.0 keeps the local recording until the server confirms, so the recovery prompt can restore it on the next load, but the user gets no heads-up while the upload runs and has to go through recovery afterward.

## Root cause

The `beforeunload` handler in `app.modular.js` warns about unsaved and incognito recordings. It does not check the upload queue, so an upload in progress never triggers the browser's "leave site?" prompt.

## Fix

Warn when any upload-queue item is `queued`, `ready`, or `uploading`. Items already at `pending` or `failed` sit on the server or in retry storage, so they stay silent.

## Tests

No new unit tests: the change is one status check in the `beforeunload` handler, with no logic worth extracting. The existing suite stays green, and `npm test` reports 51 passing.

## Notes

- This follows #287. The local copy now survives the upload, so the change spares the user the interruption and the recovery step rather than preventing data loss.
- I have read CONTRIBUTING.md and CLA.md, and I agree to the terms of the CLA.
