### PR TITLE
Fix unclosed div in folder modal that hid the API token modals

### DIFF
--- a/templates/account.html
+++ b/templates/account.html
@@ -2513,6 +2513,7 @@ curl "https://your-speakr-instance.com/api/recordings?token=YOUR_TOKEN_HERE"</co
                 </div>
 
                 </div><!-- /.modal-tabs-pane -->
+                </div><!-- /.modal-body -->
 
                 <div class="flex justify-end space-x-3 pt-4 border-t border-[var(--border-primary)]">
                     <button type="button" id="cancelFolderBtn" class="px-4 py-2 bg-[var(--bg-tertiary)] text-[var(--text-secondary)] rounded-md hover:bg-[var(--border-secondary)]" data-i18n="buttons.cancel">Cancel</button>


### PR DESCRIPTION
## Summary

On the **Account → API Tokens** tab, clicking **Create Token** appeared to do nothing: no modal opened and no token could be created from the UI.

## Root cause

In `templates/account.html`, the `#folderModal` block opens `<div class="modal-body space-y-4">` right after its `<form>` but never closes it. The browser therefore absorbs the following siblings — `#createTokenModal` and `#tokenSecretModal` — as **children** of `#folderModal`, which carries the `.hidden` (`display: none`) class by default.

So clicking **Create Token** *did* toggle the modal's `.hidden` class as expected, but the modal still rendered at `0×0` / `opacity: 0` because its parent `#folderModal` stayed `display: none`. The button looked dead, and API tokens couldn't be created through the UI at all.

This was confirmed live: the click handler fires and removes `hidden` from `#createTokenModal`, yet `getBoundingClientRect()` returns `0×0`. Walking the DOM shows `#createTokenModal.parentElement === #folderModal` (which is `display:none`). The `POST /api/tokens` backend works fine when called directly — this is purely the markup.

## Fix

Close `.modal-body` before the footer, matching the structure already used by the adjacent `#createTokenModal` (where `.modal-body` and the footer are siblings inside `<form>`). This restores `#createTokenModal` and `#tokenSecretModal` as siblings of `#folderModal` so they render correctly.

One-line change:

```diff
                 </div><!-- /.modal-tabs-pane -->
+                </div><!-- /.modal-body -->

                 <div class="flex justify-end space-x-3 pt-4 border-t border-[var(--border-primary)]">
```

After the fix, the `#folderModal` block is `<div>`/`</div>` balanced (41/41), and the Create Token / token-secret modals display and function normally.

## Testing

- Verified the `#folderModal` block div balance goes from 41 open / 40 close → 41/41.
- Confirmed the intended structure matches the working `#createTokenModal` (`.modal-body` closed before footer, both inside `<form>`).