### PR TITLE
Fix TransactionInactiveError when persisting failed uploads to IndexedDB

### DIFF
--- a/static/js/modules/db/failed-uploads.js
+++ b/static/js/modules/db/failed-uploads.js
@@ -52,8 +52,6 @@ export const initDB = () => {
 export const storeFailedUpload = async (uploadData) => {
     try {
         const db = await initDB();
-        const transaction = db.transaction([STORE_NAME], 'readwrite');
-        const objectStore = transaction.objectStore(STORE_NAME);
 
         const failedUpload = {
             timestamp: Date.now(),
@@ -69,11 +67,17 @@ export const storeFailedUpload = async (uploadData) => {
             mimeType: uploadData.file?.type || uploadData.mimeType || 'audio/webm'
         };
 
-        // Convert File to ArrayBuffer if needed
+        // Convert File to ArrayBuffer if needed. This MUST complete before the
+        // transaction is opened: an IndexedDB transaction auto-commits as soon
+        // as control returns to the event loop with no pending request against
+        // it, so awaiting here after opening the transaction would let it
+        // finish before objectStore.add() runs (TransactionInactiveError).
         if (uploadData.file && !failedUpload.fileData) {
             failedUpload.fileData = await uploadData.file.arrayBuffer();
         }
 
+        const transaction = db.transaction([STORE_NAME], 'readwrite');
+        const objectStore = transaction.objectStore(STORE_NAME);
         const request = objectStore.add(failedUpload);
 
         return new Promise((resolve, reject) => {
@@ -153,32 +157,48 @@ export const getFailedUpload = async (id) => {
 export const updateRetryCount = async (id, retryCount, error = null) => {
     try {
         const db = await initDB();
+
+        // Read and write in a single readwrite transaction. The get() and put()
+        // are chained through onsuccess (no await between them), so a request is
+        // always pending against the transaction and it cannot auto-commit early
+        // (TransactionInactiveError). Keeping both in one transaction also makes
+        // the read-modify-write atomic against concurrent writers.
         const transaction = db.transaction([STORE_NAME], 'readwrite');
         const objectStore = transaction.objectStore(STORE_NAME);
 
-        const upload = await getFailedUpload(id);
-        if (!upload) {
-            console.warn('[FailedUploadsDB] Upload not found for retry count update');
-            return;
-        }
-
-        upload.retryCount = retryCount;
-        upload.lastRetry = Date.now();
-        if (error) {
-            upload.lastError = error;
-        }
-
         return new Promise((resolve, reject) => {
-            const request = objectStore.put(upload);
+            const getRequest = objectStore.get(id);
 
-            request.onsuccess = () => {
-                console.log(`[FailedUploadsDB] Updated retry count for upload ${id}: ${retryCount}`);
-                resolve();
+            getRequest.onsuccess = () => {
+                const upload = getRequest.result;
+                if (!upload) {
+                    console.warn('[FailedUploadsDB] Upload not found for retry count update');
+                    resolve();
+                    return;
+                }
+
+                upload.retryCount = retryCount;
+                upload.lastRetry = Date.now();
+                if (error) {
+                    upload.lastError = error;
+                }
+
+                const putRequest = objectStore.put(upload);
+
+                putRequest.onsuccess = () => {
+                    console.log(`[FailedUploadsDB] Updated retry count for upload ${id}: ${retryCount}`);
+                    resolve();
+                };
+
+                putRequest.onerror = () => {
+                    console.error('[FailedUploadsDB] Failed to update retry count:', putRequest.error);
+                    reject(putRequest.error);
+                };
             };
 
-            request.onerror = () => {
-                console.error('[FailedUploadsDB] Failed to update retry count:', request.error);
-                reject(request.error);
+            getRequest.onerror = () => {
+                console.error('[FailedUploadsDB] Failed to read upload for retry count update:', getRequest.error);
+                reject(getRequest.error);
             };
         });
     } catch (error) {

--- a/static/js/modules/db/failed-uploads.test.js
+++ b/static/js/modules/db/failed-uploads.test.js
@@ -83,3 +83,148 @@ describe('triggerLocalDownload', () => {
         expect(result).toBe(false);
     });
 });
+
+/**
+ * Regression tests for the IndexedDB transaction-lifetime bug (TransactionInactiveError).
+ *
+ * IndexedDB auto-commits ("finishes") a transaction once control returns to the
+ * event loop with no request pending against it. So `await`-ing a non-IndexedDB
+ * promise (e.g. File.arrayBuffer(), or a nested helper that opens its own
+ * transaction) between `db.transaction(...)` and the first request kills the
+ * transaction; a request chained from an earlier request's onsuccess, however,
+ * keeps it alive. The mock below models both: it commits only on a microtask
+ * checkpoint that finds no request pending, and add()/put()/get() throw if used
+ * after that, exactly like a real browser.
+ */
+describe('IndexedDB transaction lifetime', () => {
+    let originalIndexedDB;
+    let store;
+    let storeFailedUpload;
+    let updateRetryCount;
+
+    const inactiveError = (op) => new DOMException(
+        `Failed to execute '${op}' on 'IDBObjectStore': The transaction has finished.`,
+        'TransactionInactiveError'
+    );
+
+    // Build a mock that mirrors real auto-commit semantics: a transaction stays
+    // active while a request is outstanding, and commits on the first microtask
+    // checkpoint where none is.
+    const makeMockDB = () => {
+        store = new Map();
+        let nextId = 1;
+
+        const db = {
+            transaction() {
+                const tx = { _active: true, _pending: 0 };
+                // Commit if the turn yields with nothing pending against the tx.
+                const scheduleCommitCheck = () => queueMicrotask(() => {
+                    if (tx._pending === 0) tx._active = false;
+                });
+                scheduleCommitCheck();
+
+                const makeRequest = (opName, op) => {
+                    if (!tx._active) throw inactiveError(opName);
+                    tx._pending++;
+                    const request = {};
+                    queueMicrotask(() => {
+                        try {
+                            request.result = op();
+                            request.onsuccess?.();
+                        } catch (err) {
+                            request.error = err;
+                            request.onerror?.();
+                        } finally {
+                            tx._pending--;
+                            scheduleCommitCheck();
+                        }
+                    });
+                    return request;
+                };
+
+                const objectStore = {
+                    add: (value) => makeRequest('add', () => {
+                        const id = nextId++;
+                        store.set(id, { ...value, id });
+                        return id;
+                    }),
+                    put: (value) => makeRequest('put', () => {
+                        store.set(value.id, { ...value });
+                        return value.id;
+                    }),
+                    get: (id) => makeRequest('get', () => store.get(id)),
+                };
+                tx.objectStore = () => objectStore;
+                return tx;
+            },
+            objectStoreNames: { contains: () => true },
+        };
+        return db;
+    };
+
+    beforeEach(async () => {
+        // Reset the module so its cached dbInstance does not leak between tests;
+        // re-import after wiring the fresh indexedDB mock so initDB() opens it.
+        vi.resetModules();
+        originalIndexedDB = global.indexedDB;
+        const db = makeMockDB();
+        global.indexedDB = {
+            open: vi.fn(() => {
+                const request = {};
+                queueMicrotask(() => {
+                    request.result = db;
+                    request.onsuccess?.();
+                });
+                return request;
+            }),
+        };
+        ({ storeFailedUpload, updateRetryCount } = await import('./failed-uploads.js'));
+    });
+
+    afterEach(() => {
+        global.indexedDB = originalIndexedDB;
+    });
+
+    it('storeFailedUpload persists a record when the file must be read to an ArrayBuffer', async () => {
+        const file = {
+            name: 'recording.webm',
+            size: 2048,
+            type: 'audio/webm',
+            arrayBuffer: async () => new ArrayBuffer(8),
+        };
+
+        const id = await storeFailedUpload({
+            file,
+            clientId: 'client-123',
+            notes: 'n',
+            tags: ['t'],
+            asrOptions: {},
+            error: '413 Payload Too Large',
+        });
+
+        expect(id).toBeTruthy();
+        const stored = store.get(id);
+        expect(stored.fileName).toBe('recording.webm');
+        expect(stored.fileData).toBeInstanceOf(ArrayBuffer);
+        expect(stored.lastError).toBe('413 Payload Too Large');
+    });
+
+    it('updateRetryCount reads and writes in one transaction without a finished transaction', async () => {
+        // Seed a record first.
+        const file = {
+            name: 'r.webm', size: 10, type: 'audio/webm',
+            arrayBuffer: async () => new ArrayBuffer(4),
+        };
+        const id = await storeFailedUpload({ file, clientId: 'c' });
+
+        await expect(updateRetryCount(id, 2, 'still failing')).resolves.not.toThrow();
+        const updated = store.get(id);
+        expect(updated.retryCount).toBe(2);
+        expect(updated.lastError).toBe('still failing');
+    });
+
+    it('updateRetryCount resolves without writing when the id is absent', async () => {
+        await expect(updateRetryCount(999, 1, 'nope')).resolves.not.toThrow();
+        expect(store.has(999)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Symptom

Every failed upload threw `TransactionInactiveError` instead of being queued for retry, so the IndexedDB retry queue never filled and uploads fell through to the local-download fallback.

## Root cause

`storeFailedUpload` opened a readwrite transaction and *then* `await`ed `File.arrayBuffer()` before `objectStore.add()`. An IndexedDB transaction auto-commits as soon as control returns to the event loop with no request pending against it, so awaiting a non-IDB promise after opening the transaction finishes it before `add()` runs. The caller always passes a raw `File` (no pre-read `fileData`), so this fired on every failed upload.

`updateRetryCount` had the same shape — it opened a readwrite transaction then `await`ed `getFailedUpload()` (which opens its own transaction) before `put()`.

## Fix

- **`storeFailedUpload`**: move the `arrayBuffer()` conversion ahead of opening the transaction, so `add()` runs synchronously within the transaction's active window.
- **`updateRetryCount`**: read and write in a single readwrite transaction, chaining `put()` from the `get()` `onsuccess` so a request is always pending. This keeps the transaction alive, makes the read-modify-write atomic, and surfaces read errors instead of swallowing them as "not found". This mirrors the pattern already used in `static/sw.js`.

## Tests

Added regression tests in `failed-uploads.test.js` that model IDB's auto-commit-on-yield semantics — the mock transaction commits only on a microtask checkpoint with no request pending, and throws `TransactionInactiveError` if a store op is used after that. They cover both functions and fail against the pre-fix code (verified by reintroducing each bug). The mock is dependency-free; `npm test` is green (70 tests).

Relates to #297 and #287, and sits alongside the upload-recovery work in #302 / #306.

---

I have read CONTRIBUTING.md and CLA.md, and I agree to the terms of the CLA.

*Assisted by Claude (claude-opus-4-8), human-reviewed.*
