### PR TITLE
feat: contextual auto-labelling without speaker embeddings

### DIFF
--- a/src/services/speaker_identification.py
+++ b/src/services/speaker_identification.py
@@ -11,13 +11,15 @@ import json
 from flask import current_app
 
 
-def identify_speakers_from_transcript(transcription_data, user_id):
+def identify_speakers_from_transcript(transcription_data, user_id, candidate_names=None):
     """
     Identify speakers in a transcription using an LLM.
 
     Args:
         transcription_data: List of transcript segments (already parsed JSON).
         user_id: Current user's ID (for token tracking).
+        candidate_names: Optional saved speaker names. When provided, the LLM
+            may only return these exact names or an empty string.
 
     Returns:
         dict mapping original speaker labels to identified names.
@@ -69,9 +71,19 @@ def identify_speakers_from_transcript(transcription_data, user_id):
     else:
         transcript_text = formatted_transcription[:transcript_limit]
 
+    candidates = [str(name).strip() for name in (candidate_names or []) if str(name).strip()]
+    candidate_instruction = ""
+    if candidates:
+        candidate_instruction = (
+            "\nKnown speaker profiles: " + ", ".join(candidates) +
+            "\nUse only these exact names. If the transcript does not clearly support "
+            "a match, return an empty string for that speaker.\n"
+        )
+
     prompt = f"""Analyze the following conversation transcript and identify the names of the speakers based on the context and content of their dialogue.
 
 The speakers that need to be identified are: {', '.join(speaker_labels)}
+{candidate_instruction}
 
 Look for clues in the conversation such as:
 - Names mentioned by other speakers when addressing someone
@@ -162,7 +174,9 @@ JSON Response:
     current_app.logger.info(f"[Auto-Identify] Parsed identified_map: {identified_map}")
 
     # --- Sanitize identified_map ---
-    identified_map = _sanitize_identified_map(identified_map, speaker_labels)
+    identified_map = _sanitize_identified_map(
+        identified_map, speaker_labels, candidate_names=candidates
+    )
     current_app.logger.info(f"[Auto-Identify] Sanitized identified_map: {identified_map}")
 
     # Map back to original speaker labels
@@ -171,11 +185,86 @@ JSON Response:
         if temp_label in identified_map:
             final_speaker_map[original_speaker] = identified_map[temp_label]
 
+    if candidates:
+        allowed = {name.casefold(): name for name in candidates}
+        final_speaker_map = {
+            label: allowed.get(str(name).casefold(), "")
+            for label, name in final_speaker_map.items()
+        }
+
     current_app.logger.info(f"[Auto-Identify] Final speaker_map: {final_speaker_map}")
     return final_speaker_map
 
 
-def _sanitize_identified_map(identified_map, speaker_labels):
+def apply_contextual_auto_labels(recording, user):
+    """Apply opt-in LLM matches constrained to the user's saved speakers."""
+    if not user.auto_speaker_labelling or not recording.transcription:
+        return {}
+
+    from src.models import Speaker
+    from src.services.speaker_embedding_matcher import apply_speaker_names_to_transcription
+    from src.services.speaker_snippets import create_speaker_snippets
+
+    candidates = [
+        speaker.name
+        for speaker in Speaker.query.filter_by(user_id=user.id)
+        .order_by(Speaker.name.asc())
+        .all()
+        if speaker.name
+    ]
+    if not candidates:
+        current_app.logger.info(
+            "[Auto-Identify] User %s has no saved speaker profiles", user.id
+        )
+        return {}
+
+    try:
+        transcription_data = json.loads(recording.transcription)
+    except (json.JSONDecodeError, TypeError):
+        current_app.logger.warning(
+            "[Auto-Identify] Recording %s has unsupported transcription data",
+            recording.id,
+        )
+        return {}
+    if not isinstance(transcription_data, list):
+        return {}
+
+    try:
+        speaker_map = identify_speakers_from_transcript(
+            transcription_data,
+            user.id,
+            candidate_names=candidates,
+        )
+    except Exception as error:
+        current_app.logger.warning(
+            "[Auto-Identify] Contextual identification failed for recording %s: %s",
+            recording.id,
+            error,
+        )
+        return {}
+    speaker_map = {label: name for label, name in speaker_map.items() if name}
+    if not speaker_map:
+        current_app.logger.info(
+            "[Auto-Identify] No saved speaker matched recording %s", recording.id
+        )
+        return {}
+    if not apply_speaker_names_to_transcription(recording, speaker_map):
+        return {}
+
+    snippet_map = {
+        label: {"name": name, "isMe": False}
+        for label, name in speaker_map.items()
+    }
+    create_speaker_snippets(recording.id, snippet_map)
+    current_app.logger.info(
+        "[Auto-Identify] Applied saved-speaker matches to recording %s: %s",
+        recording.id,
+        speaker_map,
+    )
+    return speaker_map
+
+
+def _sanitize_identified_map(identified_map, speaker_labels, candidate_names=None):
     """
     Clean up LLM output: handle inverted maps, strip commentary,
     clear placeholders, etc.
@@ -189,6 +278,11 @@ def _sanitize_identified_map(identified_map, speaker_labels):
         current_app.logger.warning("[Auto-Identify] Detected inverted map, flipping keys/values")
         identified_map = {v: k for k, v in identified_map.items() if v}
 
+    allowed = {
+        str(name).strip().casefold(): str(name).strip()
+        for name in (candidate_names or [])
+        if str(name).strip()
+    }
     sanitized = {}
     for speaker_label, identified_name in identified_map.items():
         # Skip entries whose key isn't a valid SPEAKER_XX label
@@ -199,6 +293,9 @@ def _sanitize_identified_map(identified_map, speaker_labels):
             continue
 
         name = identified_name.strip()
+        if allowed:
+            sanitized[speaker_label] = allowed.get(name.casefold(), "")
+            continue
 
         # Clear generic placeholders
         if name.lower() in ["unknown", "n/a", "not available", "unclear", "unidentified", ""]:

--- a/src/tasks/processing.py
+++ b/src/tasks/processing.py
@@ -100,6 +100,12 @@ def resolve_hotwords(hotwords, admin_default):
     return admin_default or hotwords
 
 
+def _replace_speaker_embeddings(recording, response):
+    """Replace, rather than retain, embeddings from a previous transcription."""
+    recording.speaker_embeddings = response.speaker_embeddings or None
+    return recording.speaker_embeddings
+
+
 def _sanitize_error_message(text):
     """Trim and redact a raw exception string before persisting on a
     Recording so it stays useful but doesn't leak deployment paths or
@@ -2066,9 +2072,10 @@ def transcribe_with_connector(app_context, recording_id, filepath, original_file
                             recording.transcription = transcription_text
                             current_app.logger.info(f"Transcription completed: {len(transcription_text)} characters")
 
-                        # Store speaker embeddings if available
-                        if response.speaker_embeddings:
-                            recording.speaker_embeddings = response.speaker_embeddings
+                        # Replace old embeddings on every successful transcription.
+                        # Otherwise reprocessing with a connector that has no embedding
+                        # output can incorrectly apply stale voice matches.
+                        if _replace_speaker_embeddings(recording, response):
                             current_app.logger.info(f"Stored speaker embeddings for speakers: {list(response.speaker_embeddings.keys())}")
 
                     # If we reach here, transcription succeeded
@@ -2214,36 +2221,39 @@ def transcribe_with_connector(app_context, recording_id, filepath, original_file
                 # Don't fail transcription if usage tracking fails
                 current_app.logger.warning(f"Failed to record transcription usage: {usage_err}")
 
-            # Apply auto speaker labelling if enabled and embeddings available
-            if recording.speaker_embeddings:
-                try:
-                    from src.services.speaker_embedding_matcher import (
-                        apply_auto_speaker_labels,
-                        apply_speaker_names_to_transcription,
-                        update_speaker_profiles_from_recording
-                    )
+            # Apply opt-in speaker labelling. Voice embeddings remain the most
+            # reliable path; connectors without embeddings fall back to contextual
+            # matches constrained to the user's saved speaker names.
+            user = db.session.get(User, recording.user_id)
+            if user and user.auto_speaker_labelling:
+                if recording.speaker_embeddings:
+                    try:
+                        from src.services.speaker_embedding_matcher import (
+                            apply_auto_speaker_labels,
+                            apply_speaker_names_to_transcription,
+                            update_speaker_profiles_from_recording,
+                        )
 
-                    user = db.session.get(User, recording.user_id)
-                    if user and user.auto_speaker_labelling:
                         current_app.logger.info(f"Applying auto speaker labelling for recording {recording.id}")
                         speaker_map = apply_auto_speaker_labels(recording, user)
+                        if speaker_map and apply_speaker_names_to_transcription(recording, speaker_map):
+                            updated_count = update_speaker_profiles_from_recording(recording, speaker_map, user)
+                            current_app.logger.info(
+                                f"Applied embedding speaker matches; updated {updated_count} profiles"
+                            )
+                        elif not speaker_map:
+                            current_app.logger.info("No speakers matched for auto-labelling")
+                    except Exception as auto_label_err:
+                        current_app.logger.warning(f"Failed to apply auto speaker labelling: {auto_label_err}")
+                else:
+                    try:
+                        from src.services.speaker_identification import apply_contextual_auto_labels
 
-                        if speaker_map:
-                            current_app.logger.info(f"Auto-matched speakers: {speaker_map}")
-                            # Apply names to transcription
-                            if apply_speaker_names_to_transcription(recording, speaker_map):
-                                current_app.logger.info(f"Applied speaker names to transcription")
-                                # Update speaker profiles with new embeddings
-                                updated_count = update_speaker_profiles_from_recording(recording, speaker_map, user)
-                                if updated_count > 0:
-                                    current_app.logger.info(f"Updated {updated_count} speaker profiles with new embeddings")
-                            else:
-                                current_app.logger.warning(f"Failed to apply speaker names to transcription for recording {recording.id}")
-                        else:
-                            current_app.logger.info(f"No speakers matched for auto-labelling")
-                except Exception as auto_label_err:
-                    # Don't fail transcription if auto-labelling fails
-                    current_app.logger.warning(f"Failed to apply auto speaker labelling: {auto_label_err}")
+                        apply_contextual_auto_labels(recording, user)
+                    except Exception as auto_label_err:
+                        current_app.logger.warning(
+                            f"Failed to apply contextual speaker labelling: {auto_label_err}"
+                        )
 
             # Check if auto-summarization is disabled (admin setting or user preference)
             admin_setting = SystemSetting.get_setting('disable_auto_summarization', False)

--- a/tests/test_speaker_identification_candidates.py
+++ b/tests/test_speaker_identification_candidates.py
@@ -1,0 +1,156 @@
+"""Candidate-constrained contextual speaker identification tests."""
+
+from types import SimpleNamespace
+import json
+from unittest.mock import Mock, patch
+
+from flask import Flask
+
+from src.services.speaker_identification import (
+    apply_contextual_auto_labels,
+    identify_speakers_from_transcript,
+)
+from src.tasks.processing import _replace_speaker_embeddings
+
+
+TRANSCRIPT = [
+    {"speaker": "S01", "sentence": "Maha, can you review this?"},
+    {"speaker": "S02", "sentence": "Yes, I will send it today."},
+]
+
+
+def _completion(content):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def test_candidate_names_are_added_to_prompt_and_enforced(monkeypatch):
+    monkeypatch.delenv("AUTO_IDENTIFY_RESPONSE_SCHEMA", raising=False)
+    app = Flask(__name__)
+    with app.app_context(), patch(
+        "src.services.llm.call_llm_completion",
+        return_value=_completion('{"SPEAKER_00":"Maha","SPEAKER_01":"Jill"}'),
+    ) as call_llm, patch(
+        "src.models.SystemSetting.get_setting", return_value=30000
+    ):
+        result = identify_speakers_from_transcript(
+            TRANSCRIPT,
+            user_id=1,
+            candidate_names=["Jael", "Maha", "Siva"],
+        )
+
+    assert result == {"S01": "Maha", "S02": ""}
+    prompt = call_llm.call_args.kwargs["messages"][1]["content"]
+    assert "Known speaker profiles: Jael, Maha, Siva" in prompt
+    assert "Use only these exact names" in prompt
+
+
+def test_punctuated_saved_name_is_preserved(monkeypatch):
+    monkeypatch.delenv("AUTO_IDENTIFY_RESPONSE_SCHEMA", raising=False)
+    app = Flask(__name__)
+    with app.app_context(), patch(
+        "src.services.llm.call_llm_completion",
+        return_value=_completion('{"SPEAKER_00":"Smith, John","SPEAKER_01":""}'),
+    ), patch("src.models.SystemSetting.get_setting", return_value=30000):
+        result = identify_speakers_from_transcript(
+            TRANSCRIPT, user_id=1, candidate_names=["Smith, John"]
+        )
+
+    assert result == {"S01": "Smith, John", "S02": ""}
+
+
+def test_manual_identification_remains_unconstrained(monkeypatch):
+    monkeypatch.delenv("AUTO_IDENTIFY_RESPONSE_SCHEMA", raising=False)
+    app = Flask(__name__)
+    with app.app_context(), patch(
+        "src.services.llm.call_llm_completion",
+        return_value=_completion('{"SPEAKER_00":"Maha","SPEAKER_01":"Jill"}'),
+    ), patch("src.models.SystemSetting.get_setting", return_value=30000):
+        result = identify_speakers_from_transcript(TRANSCRIPT, user_id=1)
+
+    assert result == {"S01": "Maha", "S02": "Jill"}
+
+
+def test_reprocessing_clears_stale_speaker_embeddings():
+    recording = SimpleNamespace(speaker_embeddings={"S01": [0.1, 0.2]})
+    response = SimpleNamespace(speaker_embeddings=None)
+
+    assert _replace_speaker_embeddings(recording, response) is None
+    assert recording.speaker_embeddings is None
+
+    response.speaker_embeddings = {"S02": [0.3, 0.4]}
+    assert _replace_speaker_embeddings(recording, response) == {"S02": [0.3, 0.4]}
+    assert recording.speaker_embeddings == {"S02": [0.3, 0.4]}
+
+
+def _speaker_model(names):
+    query = Mock()
+    query.filter_by.return_value.order_by.return_value.all.return_value = [
+        SimpleNamespace(name=name) for name in names
+    ]
+    return SimpleNamespace(
+        query=query,
+        name=SimpleNamespace(asc=lambda: "speaker-name"),
+    )
+
+
+def test_contextual_auto_labelling_is_opt_in():
+    recording = SimpleNamespace(id=9, transcription=json.dumps(TRANSCRIPT))
+    user = SimpleNamespace(id=1, auto_speaker_labelling=False)
+    with patch(
+        "src.services.speaker_identification.identify_speakers_from_transcript"
+    ) as identify:
+        assert apply_contextual_auto_labels(recording, user) == {}
+    identify.assert_not_called()
+
+
+def test_contextual_auto_labelling_skips_users_without_profiles():
+    recording = SimpleNamespace(id=9, transcription=json.dumps(TRANSCRIPT))
+    user = SimpleNamespace(id=1, auto_speaker_labelling=True)
+    with Flask(__name__).app_context(), patch(
+        "src.models.Speaker", _speaker_model([])
+    ), patch(
+        "src.services.speaker_identification.identify_speakers_from_transcript"
+    ) as identify:
+        assert apply_contextual_auto_labels(recording, user) == {}
+    identify.assert_not_called()
+
+
+def test_contextual_auto_labelling_applies_only_saved_matches():
+    recording = SimpleNamespace(id=9, transcription=json.dumps(TRANSCRIPT))
+    user = SimpleNamespace(id=1, auto_speaker_labelling=True)
+    with Flask(__name__).app_context(), patch(
+        "src.models.Speaker", _speaker_model(["Jael", "Maha", "Siva"])
+    ), patch(
+        "src.services.speaker_identification.identify_speakers_from_transcript",
+        return_value={"S01": "Maha", "S02": ""},
+    ) as identify, patch(
+        "src.services.speaker_embedding_matcher.apply_speaker_names_to_transcription",
+        return_value=True,
+    ) as apply_names, patch(
+        "src.services.speaker_snippets.create_speaker_snippets"
+    ) as create_snippets:
+        result = apply_contextual_auto_labels(recording, user)
+
+    assert result == {"S01": "Maha"}
+    assert identify.call_args.kwargs["candidate_names"] == ["Jael", "Maha", "Siva"]
+    apply_names.assert_called_once_with(recording, {"S01": "Maha"})
+    create_snippets.assert_called_once_with(
+        9, {"S01": {"name": "Maha", "isMe": False}}
+    )
+
+
+def test_contextual_auto_labelling_failure_is_isolated():
+    recording = SimpleNamespace(id=9, transcription=json.dumps(TRANSCRIPT))
+    user = SimpleNamespace(id=1, auto_speaker_labelling=True)
+    with Flask(__name__).app_context(), patch(
+        "src.models.Speaker", _speaker_model(["Maha"])
+    ), patch(
+        "src.services.speaker_identification.identify_speakers_from_transcript",
+        side_effect=RuntimeError("LLM unavailable"),
+    ), patch(
+        "src.services.speaker_embedding_matcher.apply_speaker_names_to_transcription"
+    ) as apply_names:
+        assert apply_contextual_auto_labels(recording, user) == {}
+    apply_names.assert_not_called()


### PR DESCRIPTION
## Summary

Adds an opt-in contextual fallback for automatic speaker labelling when a transcription connector returns diarized speaker labels but no voice embeddings.

Speakr keeps the existing embedding-based matcher as the preferred path. When embeddings are absent and the user has enabled **automatic speaker labelling**, the fallback:

1. reads the user’s existing saved speaker profiles;
2. asks the existing LLM identification service to map transcript labels to those candidates;
3. accepts only exact saved profile names;
4. leaves unmatched labels unchanged;
5. applies accepted names before title/summary generation;
6. creates representative snippets for the matched profiles.

This is connector-independent. PR #330 motivated the use case because MOSS returns speaker labels without voice embeddings, but this PR does not depend on that connector.

## Safety and behavior

- **Opt-in only:** reuses the existing `auto_speaker_labelling` preference.
- **No arbitrary profiles:** contextual output is constrained and post-validated against the user’s saved names.
- **Unmatched labels remain unchanged:** an uncertain match returns an empty value and is not applied.
- **Embedding matching remains preferred:** recordings with fresh embeddings continue through the existing voice matcher.
- **Stale embeddings are cleared:** successful reprocessing replaces the prior embedding field, including setting it to `None` when the new connector returns none.
- **Failure isolation:** LLM or parsing failures are logged and do not fail transcription.
- **Punctuated names are preserved:** exact saved names such as `Smith, John` are validated before generic name cleanup.

## Verification

### Automated

```text
88 passed
```

Relevant suites:

- `tests/test_speaker_identification_candidates.py`
- `tests/test_api_v1_speakers.py`
- `tests/test_cov_processing.py`

New tests cover candidate prompt enforcement, exact-name validation, punctuated names, unchanged manual identification, opt-in behavior, no-profile behavior, successful application, failure isolation, and stale-embedding replacement.

### Live Speakr validation

Validated against an existing 10-minute recording containing three diarized labels and a user with four saved profiles:

```json
{
  "opt_in_enabled": true,
  "labels_before": ["S01", "S02", "S03"],
  "applied_map": {"S01": "Maha", "S02": "Jael"},
  "labels_after": ["Maha", "Jael", "S03"],
  "all_matches_are_saved_profiles": true,
  "unmatched_labels_preserved": true
}
```

The normal Speakr container was restarted after the one-off validation.

## CLA

I have read the CLA Document and I hereby sign the CLA.
