### PR TITLE
fix: add encoding_format and dimension support guard for embedding API

### DIFF
--- a/src/services/embeddings.py
+++ b/src/services/embeddings.py
@@ -48,6 +48,9 @@ try:
 except (TypeError, ValueError):
     EMBEDDING_DIMENSIONS = None
 
+_DIMENSIONS_SUPPORTED_KEYWORDS = ('text-embedding-3', 'qwen3-embedding')
+_USE_DIMENSIONS = any(kw in EMBEDDING_MODEL.lower() for kw in _DIMENSIONS_SUPPORTED_KEYWORDS)
+
 # When EMBEDDING_BASE_URL is set, embeddings are produced via an OpenAI-
 # compatible /v1/embeddings call rather than locally.
 USE_API_EMBEDDINGS = bool(EMBEDDING_BASE_URL)
@@ -158,8 +161,10 @@ def _api_embed(texts, user_id=None):
     if client is None or not texts:
         return []
 
-    kwargs = {'input': texts, 'model': EMBEDDING_MODEL}
-    if EMBEDDING_DIMENSIONS is not None:
+    # OpenAI SDK v2.x auto-injects encoding_format='base64'; override to 'float'.
+    # Only pass dimensions when the model is known to support it.
+    kwargs = {'input': texts, 'model': EMBEDDING_MODEL, 'encoding_format': 'float'}
+    if EMBEDDING_DIMENSIONS is not None and _USE_DIMENSIONS:
         kwargs['dimensions'] = EMBEDDING_DIMENSIONS
 
     last_exc = None


### PR DESCRIPTION
**Problems**

1. **\encoding_format\** - The OpenAI SDK v2.x defaults to \encoding_format='base64'\, but non-OpenAI providers may not support base64, causing \_api_embed()\ to fail on parsing the response. Explicitly setting \encoding_format='float'\ is the universal format accepted by all OpenAI-compatible providers.

2. **\dimensions\ param mismatch** - When \EMBEDDING_DIMENSIONS\ is set, the upstream code passes it unconditionally to all models. However, models like \BAAI/bge-m3\ do not support this parameter and return a 400 error, crashing the entire embedding pipeline. The \dimensions\ parameter should only be passed to models known to support it.

**Changes**

- Added \encoding_format='float'\ to the kwargs in \_api_embed()\
- Added module-level \_DIMENSIONS_SUPPORTED_KEYWORDS\ containing \	ext-embedding-3\ and \qwen3-embedding\
  > These are the two known embedding model series that support the \dimensions\ parameter. Extend this list as new compatible models emerge.
- \_USE_DIMENSIONS\ is evaluated at container startup - \dimensions\ is only passed when the model name matches a supported keyword

**Impact**

| Model | \EMBEDDING_DIMENSIONS\ set | Pass \dimensions\? |
|-------|:--------------------------:|:------------------:|
| \	ext-embedding-3-small/large\ | Yes | ✅ Yes |
| Models containing \qwen3-embedding\ | Yes | ✅ Yes |
| \BAAI/bge-m3\ and others | Yes | ❌ Silently ignored |
| Any model | Not set | ❌ No |

**Checklist**

- [x] Only one file changed, no backend data structure changes
- [x] No frontend impact