### PR TITLE
docs: add OrcaRouter as an LLM provider option in the model configuration guide

### DIFF
--- a/docs/admin-guide/model-configuration.md
+++ b/docs/admin-guide/model-configuration.md
@@ -28,6 +28,8 @@ TEXT_MODEL_NAME=openai/gpt-4o-mini
 
 **OpenRouter** (recommended for most users): Provides access to multiple AI models through a single API, often at competitive prices. Supports GPT-4, Claude, and many other models. Configure using `TEXT_MODEL_BASE_URL=https://openrouter.ai/api/v1`.
 
+**OrcaRouter**: OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, and xAI behind a single endpoint and API key. Configure using `TEXT_MODEL_BASE_URL=https://api.orcarouter.ai/v1`, `TEXT_MODEL_API_KEY=sk-orca-...`, and `TEXT_MODEL_NAME=orcarouter/auto` (or a specific model such as `openai/gpt-5.5`).
+
 **OpenAI Direct**: Use OpenAI's API directly for access to their latest models including GPT-5. Configure using `TEXT_MODEL_BASE_URL=https://api.openai.com/v1`. This option is required for GPT-5 models with their specialized parameters.
 
 **Custom Endpoints**: Speakr works with any OpenAI-compatible API endpoint, including self-hosted solutions like LocalAI, Ollama with OpenAI compatibility, or enterprise API gateways.


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a documented LLM provider option in the Model Configuration guide, alongside the existing OpenRouter and Google Gemini entries.

With one API key, users get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, and xAI behind a single endpoint. Because Speakr's LLM client is a thin base-URL swap, any Speakr pipeline that uses it (summaries, titles, event extraction, chat, speaker identification) also inherits OrcaRouter's gateway-level, zero-trust security controls for AI agents, with no application code changes. The gateway screens every prompt and response and governs every tool call on a default-deny basis, across four layers:

- **Scoped keys**: bind a key to specific models, IPs, spend caps, and expiry.
- **Guardrails**: screen for PII, secret leakage, prompt injection, and unsafe output.
- **Agent firewall**: tool allow-lists with per-argument validation.
- **Audit trail**: a record of every match, verdict, and approval decision.

I'm an engineer on the OrcaRouter team.

## What's added

- `docs/admin-guide/model-configuration.md`: new **OrcaRouter** entry in the "Choosing a Provider" section, mirroring the existing OpenRouter entry. It documents `TEXT_MODEL_BASE_URL=https://api.orcarouter.ai/v1` with `TEXT_MODEL_NAME=orcarouter/auto` (or a specific prefixed model such as `openai/gpt-5.5`), which the gateway requires.

## Verification

- Live-tested with the same client Speakr uses (openai SDK `chat.completions` against `https://api.orcarouter.ai/v1`): both `orcarouter/auto` and `openai/gpt-5.5` returned valid completions.
