### PR TITLE
Add explicit httpx dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ authlib>=1.3.0,<1.7.0
 itsdangerous>=2.1.0
 email-validator==2.2.0
 openai>=2.2.0
+httpx>=0.27.0,<1.0.0
 pywebpush==1.14.0
 werkzeug==3.1.3
 gunicorn==21.2.0


### PR DESCRIPTION
## Summary

Add `httpx>=0.27.0,<1.0.0` as an explicit application dependency while keeping the existing `openai>=2.2.0` requirement unchanged.

## Problem

Application imports `httpx` directly during application initialization. However, `httpx` was not declared in `requirements.txt`; the application implicitly relied on the OpenAI Python SDK to install it as a transitive dependency.

A clean container build resolved:

```text
openai==3.3.0
```

The installed package metadata showed that OpenAI Python 3.3.0 depends on:

```text
httpx2<3,>=2.7.0
```

It no longer installs the separate `httpx` package that application imports.

As a result, the application failed during startup with:

```text
ModuleNotFoundError: No module named 'httpx'
```

Because this import occurs during initialization, the container could not start successfully and entered a restart loop.

## Root cause

The previous implicit dependency chain was:

```text
Speakr -> openai -> httpx
```

With OpenAI Python 3.3.0, the effective dependency graph became:

```text
Speakr -> openai -> httpx2
Speakr -> httpx   # imported directly but not declared
```

## Changes

Added the following direct dependency to `requirements.txt`:

```text
httpx>=0.27.0,<1.0.0
```

The existing OpenAI SDK requirement remains unchanged:

```text
openai>=2.2.0
```

Declaring `httpx` explicitly ensures that clean installations and container builds include every package imported directly by the application, regardless of changes to the OpenAI SDK's transitive dependencies.