### PR TITLE
feat: upload files larger than the reverse proxy body limit in slices

### DIFF
--- a/docs/admin-guide/recording-sessions.md
+++ b/docs/admin-guide/recording-sessions.md
@@ -92,12 +92,19 @@ ingesting at that moment, and the retry gets that recording back.
     the origin finishes ingesting anyway.
 
     Speakr treats 524 and the rest of Cloudflare's 52x range as
-    inconclusive rather than fatal, so the session survives and the
-    user's retry replays the recording that landed instead of sending
-    the file again. Time your worst realistic upload before putting the
-    edge in front of it: if it breaches the budget, the fix is deferring
-    conversion to the job queue, which `VIDEO_RETENTION=true` already
-    does for videos whose original you want to keep.
+    inconclusive rather than fatal. The browser polls the session until
+    the ingest settles, for up to ten minutes, and then either takes the
+    recording that landed or finalizes for real if the request never
+    arrived. Nothing is re-uploaded and the user is not asked to retry;
+    the upload simply takes as long as the ingest does. Re-adding the
+    same file while an ingest is still running waits on it too, rather
+    than starting a second copy.
+
+    Time your worst realistic upload before putting the edge in front of
+    it anyway: a wait that outlives ten minutes still surfaces as a
+    failure, and the fix for that is deferring conversion to the job
+    queue, which `VIDEO_RETENTION=true` already does for videos whose
+    original you want to keep.
 
 Operationally this means in-progress sliced uploads sit in
 `UPLOAD_FOLDER/_sessions/` for up to `RECORDING_SESSION_TTL_HOURS`

--- a/docs/admin-guide/recording-sessions.md
+++ b/docs/admin-guide/recording-sessions.md
@@ -46,23 +46,34 @@ request.
 A few differences from a recorder session are worth knowing when reading
 logs:
 
-- Its `recording_session` row has `upload_filename` set. That is what
-  distinguishes the two, and each finalize route rejects the other's
-  sessions with a 409.
+- Its `recording_session` row has `kind = 'sliced_upload'`, and each
+  finalize route rejects the other kind with a 409.
 - The slices are byte ranges of one complete container, not
   MediaRecorder timeslices, so finalize does a plain byte-join with no
-  ffmpeg concat, no remux, and no container sniffing. The stored file is
-  byte-identical to what the user picked.
+  ffmpeg concat, no remux, and no container sniffing. What reaches
+  ingestion is byte-identical to what the user picked, and from there it
+  is treated exactly like a single-shot upload, conversion included.
+- The client declares the file size when it opens the session, and
+  finalize refuses to ingest slices that do not add up to it. A missing
+  or short slice fails loudly rather than becoming a truncated recording.
 - `finalize-upload` is synchronous: hashing, probing and any conversion
   happen in-request exactly as they do for `POST /upload`, so it holds
   the connection for as long as that takes and needs the same generous
-  proxy read timeout.
+  proxy read timeout. A retry after a lost response gets the first
+  call's recording back rather than re-ingesting the file.
 - An abandoned one is expired by the cleanup sweep rather than
   auto-finalized. The user still has the original file, and its slices
   are a truncated container rather than a playable partial recording.
-- Losing the finalize response loses the upload: unlike the recorder's
-  `/finalize`, it is not replayable. The client re-uploads, and
-  duplicate detection flags the second copy if the first landed.
+- A failed finalize deletes the slices with it. They cannot be reused,
+  since finalize only accepts a session that is still recording.
+
+!!! warning "`RECORDING_SESSION_COMMIT_BATCH_SIZE` must stay at 1"
+
+    Above 1, the chunk endpoint flushes its bookkeeping without
+    committing and the request teardown rolls it back, so the server
+    keeps asking for the same chunk index forever. A sliced upload gives
+    up after a few non-advancing retries and reports it; a recorder
+    session silently overwrites its first chunk and loses the recording.
 
 ## Configuration
 
@@ -195,7 +206,7 @@ on the server, or discard them.
 
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/upload/session` | Create a new session. Body: `{mime_type}`, plus `{filename}` for a sliced file upload. |
+| POST | `/upload/session` | Create a new session. Body: `{mime_type}`, plus `{filename, total_bytes}` for a sliced file upload. |
 | POST | `/upload/session/{id}/chunks/{N}` | Append chunk N (must be `chunk_count + 1`). Body is raw bytes. |
 | GET | `/upload/session/{id}` | Status of an existing session. |
 | POST | `/upload/session/{id}/finalize` | Request asynchronous stitch + transcribe kickoff. |

--- a/docs/admin-guide/recording-sessions.md
+++ b/docs/admin-guide/recording-sessions.md
@@ -25,6 +25,45 @@ so the legacy 200 MB cap and its warning still apply to them. If a recording
 did stream to the server and the user switches it to incognito in the review
 pane afterwards, the server-side chunks are deleted before processing.
 
+## Sliced uploads of files on disk
+
+The same session machinery also carries uploads of files the user already
+has on disk. A normal upload is one multipart `POST /upload` of the whole
+file, so a reverse proxy whose body limit is below the file size rejects
+it before Speakr sees it (Cloudflare's proxy caps request bodies at
+100 MB on most plans). Any file larger than one slice is instead sent as
+fixed-size byte slices through `POST /upload/session/{id}/chunks/{N}` and
+finalized with `POST /upload/session/{id}/finalize-upload`, which
+byte-joins the slices and runs the result through the same ingestion
+pipeline as a single-shot upload.
+
+This needs no configuration and is not covered by
+`ENABLE_SERVER_RECORDING_CHUNKS`, which governs the recorder only. The
+slice size is `RECORDING_SESSION_MAX_CHUNK_BYTES` (16 MB), advertised in
+the create response, and files at or below that size still go up in one
+request.
+
+A few differences from a recorder session are worth knowing when reading
+logs:
+
+- Its `recording_session` row has `upload_filename` set. That is what
+  distinguishes the two, and each finalize route rejects the other's
+  sessions with a 409.
+- The slices are byte ranges of one complete container, not
+  MediaRecorder timeslices, so finalize does a plain byte-join with no
+  ffmpeg concat, no remux, and no container sniffing. The stored file is
+  byte-identical to what the user picked.
+- `finalize-upload` is synchronous: hashing, probing and any conversion
+  happen in-request exactly as they do for `POST /upload`, so it holds
+  the connection for as long as that takes and needs the same generous
+  proxy read timeout.
+- An abandoned one is expired by the cleanup sweep rather than
+  auto-finalized. The user still has the original file, and its slices
+  are a truncated container rather than a playable partial recording.
+- Losing the finalize response loses the upload: unlike the recorder's
+  `/finalize`, it is not replayable. The client re-uploads, and
+  duplicate detection flags the second copy if the first landed.
+
 ## Configuration
 
 Environment variables, all optional:
@@ -50,7 +89,8 @@ so neither is killed in flight.
 
 ```nginx
 location /upload/session/ {
-    # Chunk POSTs are small; keep timeouts modest.
+    # Chunk POSTs are capped at RECORDING_SESSION_MAX_CHUNK_BYTES (16 MB),
+    # whether they carry a recorder timeslice or a file slice.
     proxy_pass http://speakr_upstream;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -60,9 +100,10 @@ location /upload/session/ {
     proxy_read_timeout 30s;
 }
 
-location ~* ^/upload/session/.+/finalize$ {
-    # Finalize triggers ffmpeg concat which can take tens of seconds
-    # for long recordings. Give it room.
+location ~* ^/upload/session/.+/finalize(-upload)?$ {
+    # Finalize triggers ffmpeg concat which can take tens of seconds for
+    # long recordings, and finalize-upload also hashes, probes and may
+    # convert the file in-request. Give it room.
     proxy_pass http://speakr_upstream;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -80,7 +121,7 @@ the larger timeout; finalize will get the headroom it needs.
 ### Caddy
 
 ```
-@finalize path_regexp ^/upload/session/[^/]+/finalize$
+@finalize path_regexp ^/upload/session/[^/]+/finalize(-upload)?$
 handle @finalize {
     reverse_proxy speakr:8899 {
         transport http {
@@ -103,6 +144,7 @@ LimitRequestBody 33554432
 UPLOAD_FOLDER/_sessions/
   <uuid-1>/
     session.json
+    joined.bin              ← sliced uploads only, during finalize
     chunk-000001.bin
     chunk-000002.bin
     ...
@@ -153,10 +195,11 @@ on the server, or discard them.
 
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/upload/session` | Create a new session. Body: `{mime_type}`. |
+| POST | `/upload/session` | Create a new session. Body: `{mime_type}`, plus `{filename}` for a sliced file upload. |
 | POST | `/upload/session/{id}/chunks/{N}` | Append chunk N (must be `chunk_count + 1`). Body is raw bytes. |
 | GET | `/upload/session/{id}` | Status of an existing session. |
 | POST | `/upload/session/{id}/finalize` | Request asynchronous stitch + transcribe kickoff. |
+| POST | `/upload/session/{id}/finalize-upload` | Reassemble a sliced file upload and ingest it. Body is the `POST /upload` form without the file. |
 | DELETE | `/upload/session/{id}` | Abort and remove the on-disk chunks. |
 
 All endpoints require an authenticated session. The CSRF token from the

--- a/docs/admin-guide/recording-sessions.md
+++ b/docs/admin-guide/recording-sessions.md
@@ -67,6 +67,27 @@ logs:
 - A failed finalize deletes the slices with it. They cannot be reused,
   since finalize only accepts a session that is still recording.
 
+### Resuming
+
+An upload interrupted by the network is not restarted. The browser keeps
+the session id in `localStorage` under the file's identity (name, size,
+last-modified), so adding the same file again continues from the slice
+count the server reports rather than from zero, which is what makes the
+feature usable on a link bad enough to need it.
+
+Only a rejection the server would repeat (an oversize slice, an
+exhausted quota, slices that do not add up) deletes the session, because
+retrying that costs the user another full transfer for the same answer.
+A dropped connection or a timeout leaves the session alone, including
+when it happens waiting for `finalize-upload`: the server may be
+ingesting at that moment, and the retry gets that recording back.
+
+Operationally this means in-progress sliced uploads sit in
+`UPLOAD_FOLDER/_sessions/` for up to `RECORDING_SESSION_TTL_HOURS`
+waiting for a resume that may never come, and count against
+`RECORDING_SESSION_MAX_BYTES_PER_USER` until the sweep expires them.
+The browser forgets a session after 24 hours regardless.
+
 !!! warning "`RECORDING_SESSION_COMMIT_BATCH_SIZE` must stay at 1"
 
     Above 1, the chunk endpoint flushes its bookkeeping without

--- a/docs/admin-guide/recording-sessions.md
+++ b/docs/admin-guide/recording-sessions.md
@@ -132,6 +132,7 @@ Environment variables, all optional:
 | `RECORDING_SESSION_MAX_CHUNK_BYTES` | `16777216` (16 MB) | Per-chunk upload cap. Generous; MediaRecorder chunks are typically <1 MB. |
 | `RECORDING_SESSION_ALLOWED_MIME_TYPES` | `audio/webm,audio/ogg,audio/mp4,audio/mpeg,audio/wav,audio/x-m4a,video/webm,video/mp4` | Comma-separated whitelist. The video types carry the optional tab/window/screen video capture. |
 | `RECORDING_SESSION_CLEANUP_INTERVAL_SECONDS` | `3600` | How often the background thread sweeps expired sessions. Set to `0` to disable. |
+| `RECORDING_SESSION_INGEST_CEILING_SECONDS` | `900` | How long a sliced upload's in-request ingest can possibly still be running. Past this, a session left `finalizing` is taken over by the next finalize. Keep it above the WSGI request timeout (gunicorn ships with `--timeout 600`), never below, or a live ingest could be claimed twice. |
 | `RECORDING_MAX_HOURS` | `8` | Absolute ceiling on a single recording. Stops the recorder automatically at this duration regardless of size; a toast warns the user at 80% of the ceiling. |
 | `RECORDING_VIDEO_KBPS` | `2500` | Video bitrate cap (kbps) for the opt-in tab/window/screen video capture. At the default, an hour of capture is roughly 1 GB. |
 
@@ -246,6 +247,17 @@ on the server, or discard them.
   cap, the API returns 507 on `POST /upload/session` and on chunk
   uploads that would exceed the cap. Surfaced to the user as a quota
   banner.
+- **Deploys interrupt sliced uploads that are ingesting.** A sliced
+  upload ingests inside the finalize request, so recreating the
+  container mid-ingest loses that work and leaves the session
+  `finalizing` with nobody running it. Nothing is lost and nothing
+  leaks: the slices stay on disk and the user's retry takes the session
+  over once its claim is older than
+  `RECORDING_SESSION_INGEST_CEILING_SECONDS`, re-ingesting from the
+  slices already delivered. But a retry *before* that point waits ten
+  minutes and then fails, so a deploy is best timed when nothing is
+  uploading. Slice POSTs and recorder sessions are unaffected: those
+  requests are short, and their retries resume.
 
 ## API
 

--- a/docs/admin-guide/recording-sessions.md
+++ b/docs/admin-guide/recording-sessions.md
@@ -132,7 +132,7 @@ Environment variables, all optional:
 | `RECORDING_SESSION_MAX_CHUNK_BYTES` | `16777216` (16 MB) | Per-chunk upload cap. Generous; MediaRecorder chunks are typically <1 MB. |
 | `RECORDING_SESSION_ALLOWED_MIME_TYPES` | `audio/webm,audio/ogg,audio/mp4,audio/mpeg,audio/wav,audio/x-m4a,video/webm,video/mp4` | Comma-separated whitelist. The video types carry the optional tab/window/screen video capture. |
 | `RECORDING_SESSION_CLEANUP_INTERVAL_SECONDS` | `3600` | How often the background thread sweeps expired sessions. Set to `0` to disable. |
-| `RECORDING_SESSION_INGEST_CEILING_SECONDS` | `900` | How long a sliced upload's in-request ingest can possibly still be running. Past this, a session left `finalizing` is taken over by the next finalize. Keep it above the WSGI request timeout (gunicorn ships with `--timeout 600`), never below, or a live ingest could be claimed twice. |
+| `RECORDING_SESSION_INGEST_HEARTBEAT_SECONDS` | `30` | How often a sliced upload's in-request ingest stamps its session to say it is alive. Three missed stamps mark the session abandoned, and the next finalize takes it over. Nothing else can tell: under gunicorn's `gthread` worker, which is what Speakr ships, `--timeout` bounds the accept loop's silence rather than a request's duration, so a long ingest is never aborted and its session's age says nothing about whether anyone is still working on it. |
 | `RECORDING_MAX_HOURS` | `8` | Absolute ceiling on a single recording. Stops the recorder automatically at this duration regardless of size; a toast warns the user at 80% of the ceiling. |
 | `RECORDING_VIDEO_KBPS` | `2500` | Video bitrate cap (kbps) for the opt-in tab/window/screen video capture. At the default, an hour of capture is roughly 1 GB. |
 
@@ -250,14 +250,19 @@ on the server, or discard them.
 - **Deploys interrupt sliced uploads that are ingesting.** A sliced
   upload ingests inside the finalize request, so recreating the
   container mid-ingest loses that work and leaves the session
-  `finalizing` with nobody running it. Nothing is lost and nothing
-  leaks: the slices stay on disk and the user's retry takes the session
-  over once its claim is older than
-  `RECORDING_SESSION_INGEST_CEILING_SECONDS`, re-ingesting from the
-  slices already delivered. But a retry *before* that point waits ten
-  minutes and then fails, so a deploy is best timed when nothing is
-  uploading. Slice POSTs and recorder sessions are unaffected: those
-  requests are short, and their retries resume.
+  `finalizing` with nobody running it. The slices stay on disk, the
+  stamping stops with the container, and about a minute and a half
+  later the user's retry takes the session over and re-ingests from the
+  slices already delivered. A retry inside that window is told the
+  session is being finalized and waits. Slice POSTs and recorder
+  sessions are unaffected: those requests are short, and their retries
+  resume. Still worth timing a deploy for when nothing is uploading,
+  since the interrupted ingest's work is thrown away either way.
+- **The upload staging directory has no sweeper.** An ingest killed
+  mid-flight leaves its staged copy of the file behind, and nothing
+  removes it: the session sweep only owns `_sessions/`. This is not
+  specific to sliced uploads, `POST /upload` behaves the same way, but
+  it is worth a glance at `UPLOAD_FOLDER/_staging` after an incident.
 
 ## API
 

--- a/docs/admin-guide/recording-sessions.md
+++ b/docs/admin-guide/recording-sessions.md
@@ -82,6 +82,23 @@ A dropped connection or a timeout leaves the session alone, including
 when it happens waiting for `finalize-upload`: the server may be
 ingesting at that moment, and the retry gets that recording back.
 
+!!! note "Behind Cloudflare, mind the 125-second Proxy Read Timeout"
+
+    `finalize-upload` ingests in-request, exactly as `POST /upload`
+    does: hash, ffprobe, and audio extraction or codec conversion. For
+    audio that is a sub-second call, but extracting the audio from a
+    long video can outlast Cloudflare's 125-second Proxy Read Timeout
+    (not adjustable below Enterprise). The edge then answers 524 while
+    the origin finishes ingesting anyway.
+
+    Speakr treats 524 and the rest of Cloudflare's 52x range as
+    inconclusive rather than fatal, so the session survives and the
+    user's retry replays the recording that landed instead of sending
+    the file again. Time your worst realistic upload before putting the
+    edge in front of it: if it breaches the budget, the fix is deferring
+    conversion to the job queue, which `VIDEO_RETENTION=true` already
+    does for videos whose original you want to keep.
+
 Operationally this means in-progress sliced uploads sit in
 `UPLOAD_FOLDER/_sessions/` for up to `RECORDING_SESSION_TTL_HOURS`
 waiting for a resume that may never come, and count against

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,6 +20,10 @@ A per-recording Stats tab shows total length, speaker count, conversation turns,
 
 An opt-in mode (`ENABLE_SERVER_RECORDING_CHUNKS`) streams in-app recording chunks to the server as you record instead of buffering them in browser memory, raising the practical recording ceiling to hours-long sessions and letting you resume a recording after a page reload. See the [Recording guide](user-guide/recording.md#server-side-recording-sessions-long-recordings) and [admin setup](admin-guide/recording-sessions.md).
 
+### Sliced File Uploads
+
+Uploads of files larger than 16 MB are sent as fixed-size slices through the same session endpoints and reassembled server-side, so a reverse proxy with a request-body limit below the file size (Cloudflare caps bodies at 100 MB on most plans) no longer blocks large uploads. This needs no configuration; see [Recording Sessions](admin-guide/recording-sessions.md#sliced-uploads-of-files-on-disk).
+
 ## Core Transcription Features
 
 ### Multi-Engine Support

--- a/src/api/recording_sessions.py
+++ b/src/api/recording_sessions.py
@@ -107,6 +107,22 @@ def _max_chunk_bytes():
     return int(os.environ.get('RECORDING_SESSION_MAX_CHUNK_BYTES', str(16 * 1024 * 1024)))
 
 
+def _ingest_ceiling_seconds():
+    """How long a finalize's ingest can possibly still be running.
+
+    A sliced upload's ingest happens inside the request, so no ingest
+    outlives the WSGI server's own request timeout (gunicorn runs with
+    ``--timeout 600``). Past this, a session still marked ``finalizing``
+    belongs to a worker that no longer exists, typically because the
+    container was recreated mid-ingest, and the next finalize may take it
+    over. Set it above the deployment's request timeout, never below.
+    """
+    try:
+        return max(60, int(os.environ.get('RECORDING_SESSION_INGEST_CEILING_SECONDS', '900')))
+    except (TypeError, ValueError):
+        return 900
+
+
 def _commit_batch_size():
     """How many chunks to accumulate before committing session bookkeeping.
 
@@ -611,6 +627,12 @@ def finalize_sliced_upload(session_id):
     user's. What the slices weigh together is checked against the size
     declared at create, so a short or missing slice fails loudly instead
     of ingesting as a truncated recording.
+
+    A session already ``finalizing`` is claimable again once its claim is
+    older than :func:`_ingest_ceiling_seconds`, which no live ingest can
+    be: that state otherwise outlives the worker that owned it whenever a
+    container is recreated mid-ingest, and the user's retry would wait
+    for an ingest nobody is running until the TTL sweep, a day later.
     """
     session = db.session.get(RecordingSession, session_id)
     err = _ensure_owned(session)
@@ -625,19 +647,26 @@ def finalize_sliced_upload(session_id):
     if session.status == 'finalized':
         return _replay_sliced_upload_response(session)
 
-    if session.status != 'recording':
+    if session.status not in ('recording', 'finalizing'):
         return jsonify({
             'error': f'Session is in status {session.status!r}; cannot finalize',
         }), 409
 
+    now = datetime.utcnow()
+    abandoned_before = now - timedelta(seconds=_ingest_ceiling_seconds())
     claimed = db.session.query(RecordingSession).filter(
         RecordingSession.id == session.id,
-        RecordingSession.status == 'recording',
-    ).update({'status': 'finalizing'}, synchronize_session=False)
+        db.or_(
+            RecordingSession.status == 'recording',
+            db.and_(
+                RecordingSession.status == 'finalizing',
+                RecordingSession.last_seen_at < abandoned_before,
+            ),
+        ),
+    ).update({'status': 'finalizing', 'last_seen_at': now}, synchronize_session=False)
     if not claimed:
         db.session.rollback()
         return jsonify({'error': 'Session is already being finalized'}), 409
-    session.last_seen_at = datetime.utcnow()
     db.session.commit()
 
     dir_path = _session_dir(session.id)

--- a/src/api/recording_sessions.py
+++ b/src/api/recording_sessions.py
@@ -13,10 +13,21 @@ Endpoints
     POST   /upload/session/<sid>/chunks/<n>      append chunk (n=1..)
     GET    /upload/session/<sid>                 status
     POST   /upload/session/<sid>/finalize        request stitch
+    POST   /upload/session/<sid>/finalize-upload reassemble a sliced file
     DELETE /upload/session/<sid>                 abort + cleanup
 
 All endpoints require login. They write the on-disk layout described in
 ``src/models/recording_session.py``.
+
+Creating a session with a ``filename`` makes it a sliced upload of a file
+the user already has on disk (used to cross a reverse proxy whose body
+limit is below the file size) rather than a recorder session. Those
+sessions share create / chunk / abort with the recorder but finalize
+through ``/finalize-upload``, which byte-joins the slices and hands the
+result to the same ingestion pipeline ``POST /upload`` uses. The declared
+mime type is not checked against ``RECORDING_SESSION_ALLOWED_MIME_TYPES``
+for them: the user picks the container, and ffprobe gates it at ingest.
+The two finalize routes reject each other's sessions.
 
 Finalize is async: the endpoint creates a placeholder Recording row in
 ``STITCHING`` status, enqueues a ``stitch`` job via the existing
@@ -49,6 +60,7 @@ from flask_login import login_required, current_user
 from src.database import db
 from src.models import RecordingSession, Recording, RECORDING_SESSION_STATUSES
 from src.services.job_queue import job_queue
+from src.services.recording_stitch import byte_join, session_chunk_paths
 
 
 recording_sessions_bp = Blueprint('recording_sessions', __name__)
@@ -263,17 +275,27 @@ def _replay_finalize_response(session):
 def create_session():
     """Create a new in-progress recording session.
 
-    Body (JSON, all optional): {"mime_type": "audio/webm"}.
+    Body (JSON, all optional): ``{"mime_type": "audio/webm"}`` for a
+    recorder session, plus ``{"filename": "talk.mp4"}`` to make it a
+    sliced upload of a file the user already has on disk.
 
     Returns ``{session_id, expires_at, max_chunk_bytes}`` on success.
     """
     data = request.get_json(silent=True) or {}
-    mime_type = (data.get('mime_type') or 'audio/webm').strip().lower()
-    if mime_type not in _allowed_mime_types():
-        return jsonify({
-            'error': f'Unsupported mime_type {mime_type!r}',
-            'allowed': sorted(_allowed_mime_types()),
-        }), 400
+    declared_mime = (data.get('mime_type') or '').strip().lower()
+    upload_filename = (data.get('filename') or '').strip()
+
+    if upload_filename:
+        if len(upload_filename) > 255:
+            return jsonify({'error': 'filename must be 255 characters or fewer'}), 400
+        mime_type = declared_mime or 'application/octet-stream'
+    else:
+        mime_type = declared_mime or 'audio/webm'
+        if mime_type not in _allowed_mime_types():
+            return jsonify({
+                'error': f'Unsupported mime_type {mime_type!r}',
+                'allowed': sorted(_allowed_mime_types()),
+            }), 400
 
     # Per-user quota check before we let them open another session.
     if _user_bytes_in_progress(current_user.id) >= _max_bytes_per_user():
@@ -285,6 +307,7 @@ def create_session():
     session = RecordingSession(
         user_id=current_user.id,
         mime_type=mime_type,
+        upload_filename=upload_filename or None,
         status='recording',
     )
     db.session.add(session)
@@ -304,6 +327,7 @@ def create_session():
     return jsonify({
         'session_id': session.id,
         'mime_type': session.mime_type,
+        'upload_filename': session.upload_filename,
         'status': session.status,
         'expires_at': expires_at.isoformat(),
         'max_chunk_bytes': _max_chunk_bytes(),
@@ -438,6 +462,11 @@ def finalize_session(session_id):
     if err is not None:
         return err
 
+    if session.upload_filename:
+        return jsonify({
+            'error': 'Session is a sliced file upload; finalize it with /finalize-upload',
+        }), 409
+
     if session.status not in ('recording', 'finalizing'):
         return jsonify({
             'error': f'Session is in status {session.status!r}; cannot finalize',
@@ -523,6 +552,127 @@ def finalize_session(session_id):
     }), 202
 
 
+class ReassembledUpload:
+    """A Werkzeug ``FileStorage``-shaped view of reassembled slices.
+
+    Exposes only what :func:`ingest_uploaded_recording` asks of an upload
+    (``filename``, ``seek``, ``tell``, ``save``) so a sliced upload runs
+    through the same ingestion pipeline as a single-shot one. ``save``
+    moves the joined file rather than copying it, so a large upload is
+    written once.
+    """
+
+    def __init__(self, path, filename):
+        self._path = path
+        self.filename = filename
+        self._size = os.path.getsize(path)
+        self._pos = 0
+
+    def seek(self, offset, whence=os.SEEK_SET):
+        if whence == os.SEEK_END:
+            self._pos = self._size + offset
+        elif whence == os.SEEK_CUR:
+            self._pos += offset
+        else:
+            self._pos = offset
+        return self._pos
+
+    def tell(self):
+        return self._pos
+
+    def save(self, dst):
+        shutil.move(self._path, dst)
+
+
+@recording_sessions_bp.route('/upload/session/<string:session_id>/finalize-upload', methods=['POST'])
+@login_required
+def finalize_sliced_upload(session_id):
+    """Reassemble a sliced file upload and ingest it.
+
+    The body is the same multipart form ``POST /upload`` takes, minus the
+    file part: the bytes come from the session's slices instead. The
+    response is that endpoint's response, so a client can treat the two
+    transports interchangeably.
+
+    Unlike the recorder's ``/finalize``, this is synchronous and not
+    replayable: ingestion (hash, probe, convert) happens in-request
+    exactly as it does for a single-shot upload. A client that loses the
+    response has to re-upload, and Speakr's duplicate detection flags the
+    second copy. Concurrent calls are claimed atomically so only one of
+    them ingests.
+    """
+    session = db.session.get(RecordingSession, session_id)
+    err = _ensure_owned(session)
+    if err is not None:
+        return err
+
+    if not session.upload_filename:
+        return jsonify({
+            'error': 'Session is a recorder session; finalize it with /finalize',
+        }), 409
+
+    if session.status != 'recording':
+        return jsonify({
+            'error': f'Session is in status {session.status!r}; cannot finalize',
+        }), 409
+
+    dir_path = _session_dir(session.id)
+    slice_paths = session_chunk_paths(dir_path)
+    if not slice_paths or len(slice_paths) != session.chunk_count:
+        return jsonify({
+            'error': 'Slices on disk do not match the session',
+            'expected_chunk_index': len(slice_paths) + 1,
+            'chunk_count': session.chunk_count,
+        }), 409
+
+    claimed = db.session.query(RecordingSession).filter(
+        RecordingSession.id == session.id,
+        RecordingSession.status == 'recording',
+    ).update({'status': 'finalizing'}, synchronize_session=False)
+    if not claimed:
+        db.session.rollback()
+        return jsonify({'error': 'Session is already being finalized'}), 409
+    session.last_seen_at = datetime.utcnow()
+    db.session.commit()
+
+    joined_path = os.path.join(dir_path, 'joined.bin')
+    try:
+        byte_join(slice_paths, joined_path)
+    except OSError as e:
+        current_app.logger.error(f"Could not join slices for session {session_id}: {e}")
+        _fail_sliced_upload(session, f'Could not reassemble slices: {e}')
+        return jsonify({'error': 'Server could not reassemble the uploaded slices'}), 500
+
+    from src.api.recordings import ingest_uploaded_recording
+    result = ingest_uploaded_recording(
+        owner=current_user,
+        uploaded_file=ReassembledUpload(joined_path, session.upload_filename),
+        form=request.form,
+        original_filename=session.upload_filename,
+    )
+
+    response, status = result if isinstance(result, tuple) else (result, 200)
+    if 200 <= status < 300:
+        body = response.get_json(silent=True) or {}
+        session.status = 'finalized'
+        session.finalized_at = datetime.utcnow()
+        session.finalized_recording_id = body.get('id')
+        session.last_seen_at = datetime.utcnow()
+        db.session.commit()
+    else:
+        _fail_sliced_upload(session, f'Ingestion rejected the upload (HTTP {status})')
+
+    _remove_session_dir(session_id)
+    return result
+
+
+def _fail_sliced_upload(session, message):
+    session.status = 'failed'
+    session.error_message = message
+    session.last_seen_at = datetime.utcnow()
+    db.session.commit()
+
+
 @recording_sessions_bp.route('/upload/session/<string:session_id>', methods=['DELETE'])
 @login_required
 def abort_session(session_id):
@@ -563,6 +713,9 @@ def cleanup_expired_sessions(app=None):
       what was uploaded and land it in the user's library (same path as a
       manual finalize), rather than discarding it.
     - ``recording`` with no chunks → expire and delete the empty directory.
+    - a sliced file upload (``upload_filename`` set) → expire, whatever it
+      holds: the user still has the original file, and its slices are a
+      truncated container rather than a playable partial recording.
     - ``finalizing`` (already has a placeholder recording) but never reached
       a terminal stitch state → **re-enqueue** the stitch to unstick it
       (enqueue dedupes an already-active job). Bumping ``last_seen_at`` here
@@ -584,7 +737,7 @@ def cleanup_expired_sessions(app=None):
         finalized = rekicked = expired = 0
         for s in candidates:
             try:
-                if s.status == 'recording' and (s.chunk_count or 0) > 0:
+                if s.status == 'recording' and (s.chunk_count or 0) > 0 and not s.upload_filename:
                     when = s.created_at.strftime('%Y-%m-%d %H:%M') if s.created_at else ''
                     title = f"Recovered recording {when}".strip()
                     recovered_rec, _enq_err = _finalize_session_into_stitch(

--- a/src/api/recording_sessions.py
+++ b/src/api/recording_sessions.py
@@ -21,13 +21,14 @@ All endpoints require login. They write the on-disk layout described in
 
 Creating a session with a ``filename`` makes it a sliced upload of a file
 the user already has on disk (used to cross a reverse proxy whose body
-limit is below the file size) rather than a recorder session. Those
-sessions share create / chunk / abort with the recorder but finalize
-through ``/finalize-upload``, which byte-joins the slices and hands the
-result to the same ingestion pipeline ``POST /upload`` uses. The declared
-mime type is not checked against ``RECORDING_SESSION_ALLOWED_MIME_TYPES``
-for them: the user picks the container, and ffprobe gates it at ingest.
-The two finalize routes reject each other's sessions.
+limit is below the file size) rather than a recorder session; the row's
+``kind`` records which it is. Those sessions share create / chunk / abort
+with the recorder but finalize through ``/finalize-upload``, which
+byte-joins the slices and hands the result to the same ingestion pipeline
+``POST /upload`` uses. The declared mime type is not checked against
+``RECORDING_SESSION_ALLOWED_MIME_TYPES`` for them: the user picks the
+container, and ffprobe gates it at ingest. The two finalize routes reject
+each other's sessions.
 
 Finalize is async: the endpoint creates a placeholder Recording row in
 ``STITCHING`` status, enqueues a ``stitch`` job via the existing
@@ -56,6 +57,7 @@ from datetime import datetime, timedelta
 
 from flask import Blueprint, request, jsonify, current_app
 from flask_login import login_required, current_user
+from werkzeug.datastructures import FileStorage
 
 from src.database import db
 from src.models import RecordingSession, Recording, RECORDING_SESSION_STATUSES
@@ -276,18 +278,26 @@ def create_session():
     """Create a new in-progress recording session.
 
     Body (JSON, all optional): ``{"mime_type": "audio/webm"}`` for a
-    recorder session, plus ``{"filename": "talk.mp4"}`` to make it a
-    sliced upload of a file the user already has on disk.
+    recorder session. ``{"filename": "talk.mp4", "total_bytes": 1234}``
+    makes it a sliced upload of a file the user already has on disk;
+    ``total_bytes`` is what the reassembled file must weigh at finalize.
 
     Returns ``{session_id, expires_at, max_chunk_bytes}`` on success.
     """
     data = request.get_json(silent=True) or {}
     declared_mime = (data.get('mime_type') or '').strip().lower()
     upload_filename = (data.get('filename') or '').strip()
+    total_bytes = None
 
     if upload_filename:
         if len(upload_filename) > 255:
             return jsonify({'error': 'filename must be 255 characters or fewer'}), 400
+        try:
+            total_bytes = int(data.get('total_bytes'))
+        except (TypeError, ValueError):
+            return jsonify({'error': 'total_bytes is required for a sliced upload'}), 400
+        if total_bytes <= 0:
+            return jsonify({'error': 'total_bytes must be a positive integer'}), 400
         mime_type = declared_mime or 'application/octet-stream'
     else:
         mime_type = declared_mime or 'audio/webm'
@@ -307,7 +317,9 @@ def create_session():
     session = RecordingSession(
         user_id=current_user.id,
         mime_type=mime_type,
+        kind='sliced_upload' if upload_filename else 'recorder',
         upload_filename=upload_filename or None,
+        upload_total_bytes=total_bytes,
         status='recording',
     )
     db.session.add(session)
@@ -327,6 +339,7 @@ def create_session():
     return jsonify({
         'session_id': session.id,
         'mime_type': session.mime_type,
+        'kind': session.kind,
         'upload_filename': session.upload_filename,
         'status': session.status,
         'expires_at': expires_at.isoformat(),
@@ -462,7 +475,7 @@ def finalize_session(session_id):
     if err is not None:
         return err
 
-    if session.upload_filename:
+    if session.is_sliced_upload:
         return jsonify({
             'error': 'Session is a sliced file upload; finalize it with /finalize-upload',
         }), 409
@@ -552,35 +565,27 @@ def finalize_session(session_id):
     }), 202
 
 
-class ReassembledUpload:
-    """A Werkzeug ``FileStorage``-shaped view of reassembled slices.
+class ReassembledUpload(FileStorage):
+    """The reassembled slices, presented as the upload they stand for.
 
-    Exposes only what :func:`ingest_uploaded_recording` asks of an upload
-    (``filename``, ``seek``, ``tell``, ``save``) so a sliced upload runs
-    through the same ingestion pipeline as a single-shot one. ``save``
-    moves the joined file rather than copying it, so a large upload is
-    written once.
+    A real ``FileStorage`` over the joined file, so a sliced upload runs
+    through :func:`ingest_uploaded_recording` exactly as a single-shot one
+    does and gains no dependency on which of the class's members that
+    function happens to touch. ``save`` moves the joined file instead of
+    copying it, so a large upload is written once.
     """
 
     def __init__(self, path, filename):
+        super().__init__(
+            stream=open(path, 'rb'),
+            filename=filename,
+            content_type='application/octet-stream',
+            content_length=os.path.getsize(path),
+        )
         self._path = path
-        self.filename = filename
-        self._size = os.path.getsize(path)
-        self._pos = 0
 
-    def seek(self, offset, whence=os.SEEK_SET):
-        if whence == os.SEEK_END:
-            self._pos = self._size + offset
-        elif whence == os.SEEK_CUR:
-            self._pos += offset
-        else:
-            self._pos = offset
-        return self._pos
-
-    def tell(self):
-        return self._pos
-
-    def save(self, dst):
+    def save(self, dst, buffer_size=None):
+        self.close()
         shutil.move(self._path, dst)
 
 
@@ -594,35 +599,35 @@ def finalize_sliced_upload(session_id):
     response is that endpoint's response, so a client can treat the two
     transports interchangeably.
 
-    Unlike the recorder's ``/finalize``, this is synchronous and not
-    replayable: ingestion (hash, probe, convert) happens in-request
-    exactly as it does for a single-shot upload. A client that loses the
-    response has to re-upload, and Speakr's duplicate detection flags the
-    second copy. Concurrent calls are claimed atomically so only one of
-    them ingests.
+    Ingestion (hash, probe, convert) happens in-request exactly as it does
+    for a single-shot upload, so unlike the recorder's ``/finalize`` this
+    holds the connection for its whole duration. Concurrent calls are
+    claimed atomically so only one of them ingests, and a client that
+    lost the response gets the same recording back on its retry.
+
+    The session is claimed BEFORE its directory is read, because a slice
+    POST still in flight would otherwise be able to land between the
+    listing and the join, and the ingested file would be a prefix of the
+    user's. What the slices weigh together is checked against the size
+    declared at create, so a short or missing slice fails loudly instead
+    of ingesting as a truncated recording.
     """
     session = db.session.get(RecordingSession, session_id)
     err = _ensure_owned(session)
     if err is not None:
         return err
 
-    if not session.upload_filename:
+    if not session.is_sliced_upload:
         return jsonify({
             'error': 'Session is a recorder session; finalize it with /finalize',
         }), 409
 
+    if session.status == 'finalized':
+        return _replay_sliced_upload_response(session)
+
     if session.status != 'recording':
         return jsonify({
             'error': f'Session is in status {session.status!r}; cannot finalize',
-        }), 409
-
-    dir_path = _session_dir(session.id)
-    slice_paths = session_chunk_paths(dir_path)
-    if not slice_paths or len(slice_paths) != session.chunk_count:
-        return jsonify({
-            'error': 'Slices on disk do not match the session',
-            'expected_chunk_index': len(slice_paths) + 1,
-            'chunk_count': session.chunk_count,
         }), 409
 
     claimed = db.session.query(RecordingSession).filter(
@@ -634,6 +639,20 @@ def finalize_sliced_upload(session_id):
         return jsonify({'error': 'Session is already being finalized'}), 409
     session.last_seen_at = datetime.utcnow()
     db.session.commit()
+
+    dir_path = _session_dir(session.id)
+    slice_paths = session_chunk_paths(dir_path)
+    slice_bytes = sum(os.path.getsize(p) for p in slice_paths)
+    if not slice_paths or slice_bytes != session.upload_total_bytes:
+        _fail_sliced_upload(session, (
+            f'Reassembled {slice_bytes} bytes from {len(slice_paths)} slices, '
+            f'expected {session.upload_total_bytes}'
+        ))
+        return jsonify({
+            'error': 'Uploaded slices do not add up to the declared file size',
+            'received_bytes': slice_bytes,
+            'expected_bytes': session.upload_total_bytes,
+        }), 409
 
     joined_path = os.path.join(dir_path, 'joined.bin')
     try:
@@ -659,18 +678,43 @@ def finalize_sliced_upload(session_id):
         session.finalized_recording_id = body.get('id')
         session.last_seen_at = datetime.utcnow()
         db.session.commit()
+        _remove_session_dir(session_id)
     else:
         _fail_sliced_upload(session, f'Ingestion rejected the upload (HTTP {status})')
-
-    _remove_session_dir(session_id)
     return result
 
 
+def _replay_sliced_upload_response(session):
+    """Answer a retry of a finalize whose response the client lost.
+
+    Without this, a lost response costs the user the whole upload again:
+    the slices are gone and the session can no longer be finalized, so
+    the client would start over on a file it already delivered in full.
+    """
+    existing = (db.session.get(Recording, session.finalized_recording_id)
+                if session.finalized_recording_id else None)
+    if existing is None or existing.user_id != current_user.id:
+        return jsonify({
+            'error': 'Session was already finalized and its recording no longer exists',
+        }), 409
+    response_data = existing.to_dict(viewer_user=current_user)
+    response_data['idempotent_replay'] = True
+    return jsonify(response_data), 202
+
+
 def _fail_sliced_upload(session, message):
+    """Mark a sliced upload failed and reclaim its slices.
+
+    The slices cannot be reused: finalize only accepts a session still in
+    ``recording``, and no sweep collects a terminal one, so leaving them
+    behind leaks the whole file until an operator notices. Which is the
+    worst possible moment, the common cause being a full disk.
+    """
     session.status = 'failed'
     session.error_message = message
     session.last_seen_at = datetime.utcnow()
     db.session.commit()
+    _remove_session_dir(session.id)
 
 
 @recording_sessions_bp.route('/upload/session/<string:session_id>', methods=['DELETE'])
@@ -679,7 +723,9 @@ def abort_session(session_id):
     """Abort an in-progress session and clean up its on-disk chunks.
 
     If the session has already finalized, this returns 409; finalized
-    sessions are owned by the stitch worker, not the user.
+    sessions are owned by the stitch worker, not the user. A sliced
+    upload that is finalizing is refused too: its slices are being read
+    in-request, so removing them would fail the ingestion under way.
     """
     session = db.session.get(RecordingSession, session_id)
     err = _ensure_owned(session)
@@ -688,6 +734,9 @@ def abort_session(session_id):
 
     if session.status == 'finalized':
         return jsonify({'error': 'Session already finalized'}), 409
+
+    if session.status == 'finalizing' and session.is_sliced_upload:
+        return jsonify({'error': 'Session is being finalized'}), 409
 
     session.status = 'aborted'
     session.last_seen_at = datetime.utcnow()
@@ -713,9 +762,13 @@ def cleanup_expired_sessions(app=None):
       what was uploaded and land it in the user's library (same path as a
       manual finalize), rather than discarding it.
     - ``recording`` with no chunks → expire and delete the empty directory.
-    - a sliced file upload (``upload_filename`` set) → expire, whatever it
-      holds: the user still has the original file, and its slices are a
-      truncated container rather than a playable partial recording.
+    - a sliced file upload → expire, whatever it holds: the user still has
+      the original file, and its slices are a truncated container rather
+      than a playable partial recording.
+
+    Expiry claims the row conditionally, so a session that came back to
+    life between the candidate query and the claim (a resumed upload, a
+    finalize) keeps its files instead of having them swept.
     - ``finalizing`` (already has a placeholder recording) but never reached
       a terminal stitch state → **re-enqueue** the stitch to unstick it
       (enqueue dedupes an already-active job). Bumping ``last_seen_at`` here
@@ -737,7 +790,7 @@ def cleanup_expired_sessions(app=None):
         finalized = rekicked = expired = 0
         for s in candidates:
             try:
-                if s.status == 'recording' and (s.chunk_count or 0) > 0 and not s.upload_filename:
+                if s.status == 'recording' and (s.chunk_count or 0) > 0 and not s.is_sliced_upload:
                     when = s.created_at.strftime('%Y-%m-%d %H:%M') if s.created_at else ''
                     title = f"Recovered recording {when}".strip()
                     recovered_rec, _enq_err = _finalize_session_into_stitch(
@@ -771,8 +824,14 @@ def cleanup_expired_sessions(app=None):
                 else:
                     # No chunks to save (or finalizing without a recording):
                     # nothing recoverable — expire and remove the directory.
-                    s.status = 'expired'
+                    claimed = db.session.query(RecordingSession).filter(
+                        RecordingSession.id == s.id,
+                        RecordingSession.status == s.status,
+                        RecordingSession.last_seen_at < cutoff,
+                    ).update({'status': 'expired'}, synchronize_session=False)
                     db.session.commit()
+                    if not claimed:
+                        continue
                     _remove_session_dir(s.id, app)
                     expired += 1
             except Exception as e:

--- a/src/api/recording_sessions.py
+++ b/src/api/recording_sessions.py
@@ -50,9 +50,11 @@ what was uploaded into the user's library) and only deletes sessions that
 have nothing to recover. See that function for the full policy.
 """
 
+import contextlib
 import json
 import os
 import shutil
+import threading
 from datetime import datetime, timedelta
 
 from flask import Blueprint, request, jsonify, current_app
@@ -107,20 +109,26 @@ def _max_chunk_bytes():
     return int(os.environ.get('RECORDING_SESSION_MAX_CHUNK_BYTES', str(16 * 1024 * 1024)))
 
 
-def _ingest_ceiling_seconds():
-    """How long a finalize's ingest can possibly still be running.
+def _ingest_heartbeat_seconds():
+    """How often an in-progress ingest stamps the session it is working on.
 
-    A sliced upload's ingest happens inside the request, so no ingest
-    outlives the WSGI server's own request timeout (gunicorn runs with
-    ``--timeout 600``). Past this, a session still marked ``finalizing``
-    belongs to a worker that no longer exists, typically because the
-    container was recreated mid-ingest, and the next finalize may take it
-    over. Set it above the deployment's request timeout, never below.
+    A sliced upload's ingest runs inside the request, and its liveness
+    cannot be inferred from any timeout: under gunicorn's ``gthread``
+    worker, which is what Speakr ships, ``--timeout`` bounds the accept
+    loop's silence, not a request's duration (``notify()`` fires every
+    iteration regardless of what the thread pool is doing), so a request
+    in a pool thread is never aborted. An ingest therefore says so
+    itself, every interval, and a session whose stamp has gone quiet for
+    three intervals is one whose worker is gone.
     """
     try:
-        return max(60, int(os.environ.get('RECORDING_SESSION_INGEST_CEILING_SECONDS', '900')))
+        return max(5, int(os.environ.get('RECORDING_SESSION_INGEST_HEARTBEAT_SECONDS', '30')))
     except (TypeError, ValueError):
-        return 900
+        return 30
+
+
+def _ingest_abandoned_after_seconds():
+    return _ingest_heartbeat_seconds() * 3
 
 
 def _commit_batch_size():
@@ -171,6 +179,56 @@ def _write_session_manifest(session):
             json.dump(session.to_dict(), f, indent=2)
     except Exception as e:
         current_app.logger.warning(f"Could not write session manifest for {session.id}: {e}")
+
+
+def _touch_session(app, session_id):
+    """Stamp a session as still being worked on. Best-effort by design:
+    a missed stamp costs a takeover, a raised exception would cost the
+    ingest it is reporting on."""
+    try:
+        with app.app_context():
+            db.session.query(RecordingSession).filter(
+                RecordingSession.id == session_id,
+                RecordingSession.status == 'finalizing',
+            ).update({'last_seen_at': datetime.utcnow()}, synchronize_session=False)
+            db.session.commit()
+    except Exception as e:
+        app.logger.warning(f"Could not stamp session {session_id} during ingest: {e}")
+
+
+def _beat_until_stopped(app, session_id, stop, interval):
+    while True:
+        _touch_session(app, session_id)
+        if stop.wait(interval):
+            return
+
+
+def _ingest_heartbeat(session_id):
+    """Report an ingest alive until the returned callable is invoked.
+
+    Used as a context manager so the stamping stops whichever way the
+    ingest ends, including an exception on the way out.
+    """
+    app = current_app._get_current_object()
+    stop = threading.Event()
+    beater = threading.Thread(
+        target=_beat_until_stopped,
+        args=(app, session_id, stop, _ingest_heartbeat_seconds()),
+        name=f'ingest-heartbeat-{session_id[:8]}',
+        daemon=True,
+    )
+    beater.start()
+    return contextlib.closing(_Heartbeat(stop, beater))
+
+
+class _Heartbeat:
+    def __init__(self, stop, beater):
+        self._stop = stop
+        self._beater = beater
+
+    def close(self):
+        self._stop.set()
+        self._beater.join(timeout=5)
 
 
 def _remove_session_dir(session_id, app=None):
@@ -628,11 +686,12 @@ def finalize_sliced_upload(session_id):
     declared at create, so a short or missing slice fails loudly instead
     of ingesting as a truncated recording.
 
-    A session already ``finalizing`` is claimable again once its claim is
-    older than :func:`_ingest_ceiling_seconds`, which no live ingest can
-    be: that state otherwise outlives the worker that owned it whenever a
-    container is recreated mid-ingest, and the user's retry would wait
-    for an ingest nobody is running until the TTL sweep, a day later.
+    A session already ``finalizing`` is claimable again once its ingest
+    has stopped saying it is alive (see
+    :func:`_ingest_heartbeat_seconds`). That state otherwise outlives the
+    worker that owned it whenever a container is recreated mid-ingest,
+    and the user's retry would wait for an ingest nobody is running until
+    the TTL sweep, a day later.
     """
     session = db.session.get(RecordingSession, session_id)
     err = _ensure_owned(session)
@@ -653,7 +712,7 @@ def finalize_sliced_upload(session_id):
         }), 409
 
     now = datetime.utcnow()
-    abandoned_before = now - timedelta(seconds=_ingest_ceiling_seconds())
+    abandoned_before = now - timedelta(seconds=_ingest_abandoned_after_seconds())
     claimed = db.session.query(RecordingSession).filter(
         RecordingSession.id == session.id,
         db.or_(
@@ -684,20 +743,21 @@ def finalize_sliced_upload(session_id):
         }), 409
 
     joined_path = os.path.join(dir_path, 'joined.bin')
-    try:
-        byte_join(slice_paths, joined_path)
-    except OSError as e:
-        current_app.logger.error(f"Could not join slices for session {session_id}: {e}")
-        _fail_sliced_upload(session, f'Could not reassemble slices: {e}')
-        return jsonify({'error': 'Server could not reassemble the uploaded slices'}), 500
+    with _ingest_heartbeat(session.id):
+        try:
+            byte_join(slice_paths, joined_path)
+        except OSError as e:
+            current_app.logger.error(f"Could not join slices for session {session_id}: {e}")
+            _fail_sliced_upload(session, f'Could not reassemble slices: {e}')
+            return jsonify({'error': 'Server could not reassemble the uploaded slices'}), 500
 
-    from src.api.recordings import ingest_uploaded_recording
-    result = ingest_uploaded_recording(
-        owner=current_user,
-        uploaded_file=ReassembledUpload(joined_path, session.upload_filename),
-        form=request.form,
-        original_filename=session.upload_filename,
-    )
+        from src.api.recordings import ingest_uploaded_recording
+        result = ingest_uploaded_recording(
+            owner=current_user,
+            uploaded_file=ReassembledUpload(joined_path, session.upload_filename),
+            form=request.form,
+            original_filename=session.upload_filename,
+        )
 
     response, status = result if isinstance(result, tuple) else (result, 200)
     if 200 <= status < 300:

--- a/src/api/recording_sessions.py
+++ b/src/api/recording_sessions.py
@@ -182,9 +182,18 @@ def _write_session_manifest(session):
 
 
 def _touch_session(app, session_id):
-    """Stamp a session as still being worked on. Best-effort by design:
-    a missed stamp costs a takeover, a raised exception would cost the
-    ingest it is reporting on."""
+    """Stamp a session as still being worked on.
+
+    Best-effort by design: a raised exception here would cost the ingest
+    it reports on. Three stamps missed in a row hand a live ingest's
+    session to a takeover, and since the completion path publishes
+    unconditionally, the two ingests then produce two recordings for the
+    one upload, only the later of which the session points at. It takes a
+    database unreachable for the whole of three intervals to get there.
+
+    Only a ``finalizing`` row is stamped, so a beat that arrives after
+    the ingest published cannot revive a finished session.
+    """
     try:
         with app.app_context():
             db.session.query(RecordingSession).filter(
@@ -203,12 +212,9 @@ def _beat_until_stopped(app, session_id, stop, interval):
             return
 
 
+@contextlib.contextmanager
 def _ingest_heartbeat(session_id):
-    """Report an ingest alive until the returned callable is invoked.
-
-    Used as a context manager so the stamping stops whichever way the
-    ingest ends, including an exception on the way out.
-    """
+    """Report an ingest alive for as long as the block runs, however it ends."""
     app = current_app._get_current_object()
     stop = threading.Event()
     beater = threading.Thread(
@@ -218,17 +224,11 @@ def _ingest_heartbeat(session_id):
         daemon=True,
     )
     beater.start()
-    return contextlib.closing(_Heartbeat(stop, beater))
-
-
-class _Heartbeat:
-    def __init__(self, stop, beater):
-        self._stop = stop
-        self._beater = beater
-
-    def close(self):
-        self._stop.set()
-        self._beater.join(timeout=5)
+    try:
+        yield
+    finally:
+        stop.set()
+        beater.join(timeout=5)
 
 
 def _remove_session_dir(session_id, app=None):

--- a/src/init_db.py
+++ b/src/init_db.py
@@ -653,8 +653,12 @@ def _run_migrations(app, engine):
             app.logger.warning("New recordings will work correctly, but existing dates may need manual migration")
 
     with _migration_section(app, failures, "sliced file upload sessions"):
+        if add_column_if_not_exists(engine, 'recording_session', 'kind', "VARCHAR(20) DEFAULT 'recorder'"):
+            app.logger.info("Added kind column to recording_session table")
         if add_column_if_not_exists(engine, 'recording_session', 'upload_filename', 'VARCHAR(255)'):
             app.logger.info("Added upload_filename column to recording_session table")
+        if add_column_if_not_exists(engine, 'recording_session', 'upload_total_bytes', 'BIGINT'):
+            app.logger.info("Added upload_total_bytes column to recording_session table")
 
     with _migration_section(app, failures, "performance and uniqueness indexes"):
         # Add index on TranscriptChunk.speaker_name for performance

--- a/src/init_db.py
+++ b/src/init_db.py
@@ -652,6 +652,10 @@ def _run_migrations(app, engine):
             app.logger.warning(f"Error during meeting_date migration: {e}")
             app.logger.warning("New recordings will work correctly, but existing dates may need manual migration")
 
+    with _migration_section(app, failures, "sliced file upload sessions"):
+        if add_column_if_not_exists(engine, 'recording_session', 'upload_filename', 'VARCHAR(255)'):
+            app.logger.info("Added upload_filename column to recording_session table")
+
     with _migration_section(app, failures, "performance and uniqueness indexes"):
         # Add index on TranscriptChunk.speaker_name for performance
         # This improves speaker rename operations which update all chunks

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -30,7 +30,7 @@ from .system import SystemSetting
 from .audit import ShareAuditLog
 from .push_subscription import PushSubscription
 from .processing_job import ProcessingJob
-from .recording_session import RecordingSession, RECORDING_SESSION_STATUSES
+from .recording_session import RecordingSession, RECORDING_SESSION_KINDS, RECORDING_SESSION_STATUSES
 from .token_usage import TokenUsage
 from .transcription_usage import TranscriptionUsage
 from .webhook import (
@@ -75,6 +75,7 @@ __all__ = [
     'PushSubscription',
     'ProcessingJob',
     'RecordingSession',
+    'RECORDING_SESSION_KINDS',
     'RECORDING_SESSION_STATUSES',
     'TokenUsage',
     'TranscriptionUsage',

--- a/src/models/recording_session.py
+++ b/src/models/recording_session.py
@@ -20,6 +20,16 @@ On finalize, the chunks are stitched into a single file via ffmpeg concat
 demux (handles pause/resume across MediaRecorder restarts, which a raw
 cat would corrupt). The resulting file becomes the new Recording's
 audio_path and the session directory is removed.
+
+The same session machinery also carries sliced uploads of files the user
+already has on disk, so those can cross a reverse proxy with a body-size
+limit below the file size. Such a session has ``upload_filename`` set,
+which is what distinguishes it from a recorder session. Its chunks are
+fixed-size byte slices of one complete container rather than
+MediaRecorder timeslices, so it finalizes through the normal upload
+ingestion path (plain byte-join, no stitch, no remux) and is never
+auto-finalized when abandoned: the user's original file still exists, so
+there is nothing to recover.
 """
 
 import uuid
@@ -62,6 +72,8 @@ class RecordingSession(db.Model):
     # we can validate per-chunk uploads (reject anything inconsistent with
     # the declared type) and pick the right ffmpeg input args at stitch time.
     mime_type = db.Column(db.String(100), nullable=False, default='audio/webm')
+
+    upload_filename = db.Column(db.String(255), nullable=True)
 
     # Status transitions are guarded by the API; see RECORDING_SESSION_STATUSES.
     status = db.Column(db.String(20), nullable=False, default='recording', index=True)
@@ -112,6 +124,7 @@ class RecordingSession(db.Model):
             'session_id': self.id,
             'status': self.status,
             'mime_type': self.mime_type,
+            'upload_filename': self.upload_filename,
             'chunk_count': self.chunk_count,
             'bytes_received': self.bytes_received,
             'created_at': self.created_at.isoformat() if self.created_at else None,

--- a/src/models/recording_session.py
+++ b/src/models/recording_session.py
@@ -23,13 +23,12 @@ audio_path and the session directory is removed.
 
 The same session machinery also carries sliced uploads of files the user
 already has on disk, so those can cross a reverse proxy with a body-size
-limit below the file size. Such a session has ``upload_filename`` set,
-which is what distinguishes it from a recorder session. Its chunks are
-fixed-size byte slices of one complete container rather than
-MediaRecorder timeslices, so it finalizes through the normal upload
-ingestion path (plain byte-join, no stitch, no remux) and is never
-auto-finalized when abandoned: the user's original file still exists, so
-there is nothing to recover.
+limit below the file size. ``kind`` says which of the two a session is.
+A sliced upload's chunks are fixed-size byte slices of one complete
+container rather than MediaRecorder timeslices, so it finalizes through
+the normal upload ingestion path (plain byte-join, no stitch, no remux)
+and is never auto-finalized when abandoned: the user's original file
+still exists, so there is nothing to recover.
 """
 
 import uuid
@@ -47,7 +46,12 @@ RECORDING_SESSION_STATUSES = (
     'finalized',     # stitch completed; session dir may already be removed
     'aborted',       # user (or admin) cancelled before finalize
     'expired',       # TTL elapsed without finalize; cleanup ran
-    'failed',        # stitch job hit a permanent error
+    'failed',        # stitch or ingestion hit a permanent error
+)
+
+RECORDING_SESSION_KINDS = (
+    'recorder',        # in-app recorder streaming MediaRecorder timeslices
+    'sliced_upload',   # byte slices of a file the user already has on disk
 )
 
 
@@ -73,7 +77,11 @@ class RecordingSession(db.Model):
     # the declared type) and pick the right ffmpeg input args at stitch time.
     mime_type = db.Column(db.String(100), nullable=False, default='audio/webm')
 
+    kind = db.Column(db.String(20), nullable=False, default='recorder', index=True)
+
     upload_filename = db.Column(db.String(255), nullable=True)
+
+    upload_total_bytes = db.Column(db.BigInteger, nullable=True)
 
     # Status transitions are guarded by the API; see RECORDING_SESSION_STATUSES.
     status = db.Column(db.String(20), nullable=False, default='recording', index=True)
@@ -115,6 +123,10 @@ class RecordingSession(db.Model):
     )
     finalized_recording = db.relationship('Recording', foreign_keys=[finalized_recording_id])
 
+    @property
+    def is_sliced_upload(self):
+        return self.kind == 'sliced_upload'
+
     def __repr__(self):  # pragma: no cover - debugging aid
         return f'<RecordingSession {self.id} user={self.user_id} status={self.status} chunks={self.chunk_count}>'
 
@@ -124,7 +136,9 @@ class RecordingSession(db.Model):
             'session_id': self.id,
             'status': self.status,
             'mime_type': self.mime_type,
+            'kind': self.kind,
             'upload_filename': self.upload_filename,
+            'upload_total_bytes': self.upload_total_bytes,
             'chunk_count': self.chunk_count,
             'bytes_received': self.bytes_received,
             'created_at': self.created_at.isoformat() if self.created_at else None,

--- a/src/services/recording_stitch.py
+++ b/src/services/recording_stitch.py
@@ -67,7 +67,7 @@ def _session_dir(upload_folder: str, session_id: str) -> str:
     return os.path.join(upload_folder, '_sessions', session_id)
 
 
-def _chunk_paths(session_dir: str) -> list:
+def session_chunk_paths(session_dir: str) -> list:
     """Return chunk file paths in monotonic order. ``chunk-NNNNNN.bin``
     naming sorts lexicographically by index because of the zero pad."""
     if not os.path.isdir(session_dir):
@@ -130,7 +130,7 @@ def _partition_into_segments(chunk_paths: list) -> list:
     return segments
 
 
-def _byte_join(chunk_paths: list, output_path: str) -> None:
+def byte_join(chunk_paths: list, output_path: str) -> None:
     """Raw byte concatenation in order, streamed for flat memory use."""
     with open(output_path, 'wb') as out:
         for p in chunk_paths:
@@ -212,7 +212,7 @@ def _assemble_session_audio(chunk_paths: list, output_path: str, mime_type: str)
         segment_files = []
         for i, seg_chunks in enumerate(segments):
             seg_path = os.path.join(work_dir, f'segment-{i:04d}.bin')
-            _byte_join(seg_chunks, seg_path)
+            byte_join(seg_chunks, seg_path)
             segment_files.append(seg_path)
 
         if len(segment_files) == 1:
@@ -326,7 +326,7 @@ def stitch_recording_session(session_id: str) -> Tuple[int, str, dict]:
     upload_folder = current_app.config.get('UPLOAD_FOLDER') or '/data/uploads'
     sess_dir = _session_dir(upload_folder, session_id)
 
-    chunk_paths = _chunk_paths(sess_dir)
+    chunk_paths = session_chunk_paths(sess_dir)
     if not chunk_paths:
         raise StitchError(f'session {session_id} has no chunks on disk')
 

--- a/static/js/modules/composables/upload.js
+++ b/static/js/modules/composables/upload.js
@@ -7,6 +7,7 @@ import * as FailedUploads from '../db/failed-uploads.js';
 import * as IncognitoStorage from '../db/incognito-storage.js';
 import * as RecordingDB from '../db/recording-persistence.js';
 import { getUploadCsrfToken, isCsrfRejection } from '../csrf.js';
+import { shouldSliceUpload, uploadFileInSlices } from '../db/sliced-file-upload.js';
 import { computeUploadTimeout } from '../utils/upload-timeout.js';
 
 // Parse error message and return friendly error info
@@ -467,16 +468,23 @@ export function useUpload(state, utils) {
      * Upload a single file to the server.
      * Acquires a concurrency slot, uploads, then releases.
      * Status updates are per-item (no global processingProgress).
+     *
+     * Files past the slice threshold go up through the sliced-upload
+     * transport instead of one multipart POST, so a reverse proxy whose
+     * body limit is below the file size cannot reject them. Both
+     * transports send the same form and return the same response, so
+     * everything below the transport call is shared.
      */
     const uploadSingleFile = async (fileItem) => {
         await acquireUploadSlot();
 
         fileItem.status = 'uploading';
         fileItem.progress = 5;
+        const sliced = shouldSliceUpload(fileItem.file);
 
         try {
             const formData = new FormData();
-            formData.append('file', fileItem.file);
+            if (!sliced) formData.append('file', fileItem.file);
 
             // Send file's lastModified timestamp for meeting_date
             if (fileItem.file.lastModified) {
@@ -650,18 +658,27 @@ export function useUpload(state, utils) {
                 xhr.send(formData);
             });
 
-            // Refresh the token right before sending, and retry exactly once
-            // with another fresh token if the server still rejects it —
-            // mirroring what the fetch interceptor in csrf-refresh.js does
-            // for non-XHR requests.
             let data;
-            try {
-                data = await sendUpload(await getUploadCsrfToken());
-            } catch (uploadError) {
-                if (!uploadError.isCsrfRejection) throw uploadError;
-                console.warn(`[Upload] CSRF rejection for ${fileItem.file.name}; refreshing token and retrying once.`);
-                fileItem.progress = 5;
-                data = await sendUpload(await getUploadCsrfToken());
+            if (sliced) {
+                data = await uploadFileInSlices(fileItem.file, formData, {
+                    onProgress: (fraction) => {
+                        fileItem.progress = Math.round(5 + fraction * 85);
+                    },
+                    onXhr: (xhr) => { fileItem._xhr = xhr; },
+                });
+            } else {
+                // Refresh the token right before sending, and retry exactly once
+                // with another fresh token if the server still rejects it —
+                // mirroring what the fetch interceptor in csrf-refresh.js does
+                // for non-XHR requests.
+                try {
+                    data = await sendUpload(await getUploadCsrfToken());
+                } catch (uploadError) {
+                    if (!uploadError.isCsrfRejection) throw uploadError;
+                    console.warn(`[Upload] CSRF rejection for ${fileItem.file.name}; refreshing token and retrying once.`);
+                    fileItem.progress = 5;
+                    data = await sendUpload(await getUploadCsrfToken());
+                }
             }
 
             // Upload succeeded - recording is now on the server

--- a/static/js/modules/db/sliced-file-upload.js
+++ b/static/js/modules/db/sliced-file-upload.js
@@ -108,20 +108,34 @@ export function forgetSession(file) {
     writeResumeMemory(memory);
 }
 
-/** The server's view of a session, or null when it no longer has one. */
+/**
+ * The server's view of a session.
+ *
+ * Null means the server says there is no such session, which is a fact
+ * about the session. Every other failure throws, because a status
+ * endpoint that cannot be reached says nothing about the upload behind
+ * it, and the difference decides whether a caller gives up or waits.
+ */
 async function readSessionStatus(sessionId, token) {
     const response = await fetch(`${SESSION_BASE}/${encodeURIComponent(sessionId)}`, {
         credentials: 'same-origin',
         headers: { 'X-CSRFToken': token },
     });
-    if (!response.ok) return null;
-    return parseJson(await response.text());
+    if (response.status === 404 || response.status === 403) return null;
+    if (!response.ok) {
+        const error = new Error(`Could not read the upload session (HTTP ${response.status})`);
+        error.status = response.status;
+        throw error;
+    }
+    const session = parseJson(await response.text());
+    if (!session) throw new Error('Upload session status was not JSON');
+    return session;
 }
 
 /**
  * The session we opened for this file, when it can still be continued.
- * Returns `{sessionId, sliceBytes, chunkCount, status}` or null, and
- * forgets anything the server no longer recognises.
+ * Returns `{sessionId, sliceBytes, chunkCount}` or null, and forgets
+ * anything the server no longer recognises.
  *
  * `finalizing` counts as continuable: it is what an ingest that outran
  * the proxy's patience looks like from here, and the caller waits it out
@@ -153,7 +167,6 @@ async function resumableSession(file, token) {
         sessionId: remembered.sessionId,
         sliceBytes: remembered.sliceBytes,
         chunkCount: status.chunk_count || 0,
-        status: status.status,
     };
 }
 
@@ -356,6 +369,11 @@ async function finalize(sessionId, formData, tokenRef, options) {
  * finalizes for real (`recording`, meaning the request never reached
  * Speakr at all). Only when the wait runs out does `firstError` surface,
  * with the session left in place for another attempt.
+ *
+ * A status endpoint that answers with anything but "no such session" is
+ * treated as part of the same outage: this code runs precisely where a
+ * proxy is having a bad time, so ending the wait on the first 502 from
+ * it would abandon an ingest that is still running.
  */
 async function settleUnfinishedFinalize(sessionId, formData, tokenRef, options, firstError) {
     const deadline = Date.now() + INGEST_WAIT_MS;
@@ -366,22 +384,25 @@ async function settleUnfinishedFinalize(sessionId, formData, tokenRef, options, 
         try {
             status = await readSessionStatus(sessionId, tokenRef.token);
         } catch (_) {
-            status = undefined;
-        }
-
-        if (status === null) throw firstError;
-
-        if (status?.status === 'finalizing' || status === undefined) {
             await sleep(INGEST_POLL_MS);
             continue;
         }
 
-        if (['recording', 'finalized'].includes(status.status)
-            && ++finalizeAttempts <= MAX_FINALIZE_ATTEMPTS) {
-            return await finalize(sessionId, formData, tokenRef, options);
+        if (status === null) throw firstError;
+        if (status.status === 'finalizing') {
+            await sleep(INGEST_POLL_MS);
+            continue;
         }
+        if (!['recording', 'finalized'].includes(status.status)) throw firstError;
+        if (finalizeAttempts >= MAX_FINALIZE_ATTEMPTS) throw firstError;
 
-        throw firstError;
+        finalizeAttempts += 1;
+        try {
+            return await finalize(sessionId, formData, tokenRef, options);
+        } catch (error) {
+            if (!error.resumable) throw error;
+            await sleep(INGEST_POLL_MS);
+        }
     }
 
     throw firstError;

--- a/static/js/modules/db/sliced-file-upload.js
+++ b/static/js/modules/db/sliced-file-upload.js
@@ -47,6 +47,10 @@ const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504, 520, 521,
 
 const INCONCLUSIVE_STATUSES = new Set([408, 429, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 527]);
 
+const INGEST_POLL_MS = 3000;
+const INGEST_WAIT_MS = 10 * 60 * 1000;
+const MAX_FINALIZE_ATTEMPTS = 3;
+
 const RESUME_KEY = 'speakr.slicedUploads';
 const RESUME_TTL_MS = 24 * 60 * 60 * 1000;
 const RESUME_MAX_ENTRIES = 20;
@@ -104,10 +108,24 @@ export function forgetSession(file) {
     writeResumeMemory(memory);
 }
 
+/** The server's view of a session, or null when it no longer has one. */
+async function readSessionStatus(sessionId, token) {
+    const response = await fetch(`${SESSION_BASE}/${encodeURIComponent(sessionId)}`, {
+        credentials: 'same-origin',
+        headers: { 'X-CSRFToken': token },
+    });
+    if (!response.ok) return null;
+    return parseJson(await response.text());
+}
+
 /**
- * The server's view of a session we started for this file, when it can
- * still be continued. Returns `{sessionId, sliceBytes, chunkCount}` or
- * null, and forgets anything the server no longer recognises.
+ * The session we opened for this file, when it can still be continued.
+ * Returns `{sessionId, sliceBytes, chunkCount, status}` or null, and
+ * forgets anything the server no longer recognises.
+ *
+ * `finalizing` counts as continuable: it is what an ingest that outran
+ * the proxy's patience looks like from here, and the caller waits it out
+ * rather than sending the file again.
  */
 async function resumableSession(file, token) {
     const remembered = readResumeMemory()[fileKey(file)];
@@ -115,14 +133,7 @@ async function resumableSession(file, token) {
 
     let status;
     try {
-        const response = await fetch(
-            `${SESSION_BASE}/${encodeURIComponent(remembered.sessionId)}`,
-            { credentials: 'same-origin', headers: { 'X-CSRFToken': token } });
-        if (!response.ok) {
-            forgetSession(file);
-            return null;
-        }
-        status = parseJson(await response.text());
+        status = await readSessionStatus(remembered.sessionId, token);
     } catch (error) {
         console.warn('[SlicedUpload] Could not read the remembered session:', error);
         return null;
@@ -131,7 +142,7 @@ async function resumableSession(file, token) {
     const continuable = status
         && status.kind === 'sliced_upload'
         && status.upload_total_bytes === file.size
-        && ['recording', 'finalized'].includes(status.status)
+        && ['recording', 'finalizing', 'finalized'].includes(status.status)
         && remembered.sliceBytes > 0;
     if (!continuable) {
         forgetSession(file);
@@ -142,6 +153,7 @@ async function resumableSession(file, token) {
         sessionId: remembered.sessionId,
         sliceBytes: remembered.sliceBytes,
         chunkCount: status.chunk_count || 0,
+        status: status.status,
     };
 }
 
@@ -334,6 +346,48 @@ async function finalize(sessionId, formData, tokenRef, options) {
 }
 
 /**
+ * Settle a finalize whose answer never arrived.
+ *
+ * The ingest runs in-request, so Cloudflare's 125-second Proxy Read
+ * Timeout can cut the answer off while the origin carries on and
+ * produces the recording anyway. Rather than report a failure the user
+ * has to interpret, wait the session out: once it leaves `finalizing`,
+ * asking again either replays the recording that landed (`finalized`) or
+ * finalizes for real (`recording`, meaning the request never reached
+ * Speakr at all). Only when the wait runs out does `firstError` surface,
+ * with the session left in place for another attempt.
+ */
+async function settleUnfinishedFinalize(sessionId, formData, tokenRef, options, firstError) {
+    const deadline = Date.now() + INGEST_WAIT_MS;
+    let finalizeAttempts = 1;
+
+    while (Date.now() < deadline) {
+        let status;
+        try {
+            status = await readSessionStatus(sessionId, tokenRef.token);
+        } catch (_) {
+            status = undefined;
+        }
+
+        if (status === null) throw firstError;
+
+        if (status?.status === 'finalizing' || status === undefined) {
+            await sleep(INGEST_POLL_MS);
+            continue;
+        }
+
+        if (['recording', 'finalized'].includes(status.status)
+            && ++finalizeAttempts <= MAX_FINALIZE_ATTEMPTS) {
+            return await finalize(sessionId, formData, tokenRef, options);
+        }
+
+        throw firstError;
+    }
+
+    throw firstError;
+}
+
+/**
  * Upload `file` in slices and finalize with `formData` (the same form the
  * single-shot path builds, minus the file part). Resolves to the created
  * recording, matching what POST /upload returns.
@@ -381,10 +435,18 @@ export async function uploadFileInSlices(file, formData, options = {}) {
             }
             onProgress(Math.min(1, ((index - 1) * sliceBytes) / file.size));
         }
-        const recording = await finalize(sessionId, formData, tokenRef, {
+        const finalizeOptions = {
             finalizeTimeoutMs: computeUploadTimeout(file.size),
             onXhr: options.onXhr,
-        });
+        };
+        let recording;
+        try {
+            recording = await finalize(sessionId, formData, tokenRef, finalizeOptions);
+        } catch (error) {
+            if (!error.resumable) throw error;
+            recording = await settleUnfinishedFinalize(
+                sessionId, formData, tokenRef, finalizeOptions, error);
+        }
         forgetSession(file);
         return recording;
     } catch (error) {

--- a/static/js/modules/db/sliced-file-upload.js
+++ b/static/js/modules/db/sliced-file-upload.js
@@ -32,6 +32,7 @@ const SESSION_BASE = '/upload/session';
 export const SLICE_BYTES = 16 * 1024 * 1024;
 
 const MAX_SLICE_ATTEMPTS = 6;
+const MAX_STALLED_RESYNCS = 2;
 const BASE_RETRY_MS = 1000;
 const MAX_RETRY_MS = 30000;
 
@@ -82,7 +83,11 @@ async function createFileSession(file, token) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-CSRFToken': token },
         credentials: 'same-origin',
-        body: JSON.stringify({ filename: file.name, mime_type: file.type || '' }),
+        body: JSON.stringify({
+            filename: file.name,
+            mime_type: file.type || '',
+            total_bytes: file.size,
+        }),
     });
     const body = parseJson(await response.text());
     if (response.status !== 201 || !body?.session_id) {
@@ -173,7 +178,7 @@ async function finalize(sessionId, formData, tokenRef, options) {
             onXhr: options.onXhr,
         });
         const body = parseJson(result.text);
-        if (result.status === 202 && body?.id) return body;
+        if (result.status >= 200 && result.status < 300 && body?.id) return body;
         if (isCsrfRejection(result.status, result.text) && attempt === 1) {
             tokenRef.token = await getUploadCsrfToken();
             continue;
@@ -199,6 +204,8 @@ export async function uploadFileInSlices(file, formData, options = {}) {
 
     try {
         let index = 1;
+        let highWaterMark = 0;
+        let stalledResyncs = 0;
         while ((index - 1) * sliceBytes < file.size) {
             const start = (index - 1) * sliceBytes;
             const end = Math.min(start + sliceBytes, file.size);
@@ -206,6 +213,14 @@ export async function uploadFileInSlices(file, formData, options = {}) {
                 onXhr: options.onXhr,
                 onSliceProgress: (loaded) => onProgress(Math.min(1, (start + loaded) / file.size)),
             });
+            if (index > highWaterMark) {
+                highWaterMark = index;
+                stalledResyncs = 0;
+            } else if (++stalledResyncs > MAX_STALLED_RESYNCS) {
+                throw new Error(
+                    `Server keeps asking for slice ${index} after accepting it; `
+                    + 'its slice bookkeeping is not advancing');
+            }
             onProgress(Math.min(1, ((index - 1) * sliceBytes) / file.size));
         }
         return await finalize(session.session_id, formData, tokenRef, {

--- a/static/js/modules/db/sliced-file-upload.js
+++ b/static/js/modules/db/sliced-file-upload.js
@@ -1,0 +1,219 @@
+/**
+ * Sliced upload of a file the user already has on disk.
+ *
+ * Speakr's normal upload is one multipart POST of the whole file, so a
+ * reverse proxy with a body-size limit below the file size (Cloudflare's
+ * 100 MB, for instance) rejects it before Speakr sees it. This module
+ * sends the same file as fixed-size byte slices through the
+ * recording-session endpoints instead, then POSTs the upload form to
+ * /finalize-upload, which byte-joins the slices server-side and ingests
+ * the result exactly as POST /upload would.
+ *
+ * SLICE_BYTES mirrors the server's RECORDING_SESSION_MAX_CHUNK_BYTES
+ * default; the create response is authoritative, so a deployment that
+ * lowered that env var lowers the slice size with it.
+ *
+ * It deliberately does NOT reuse server-recording-sessions.js's
+ * createSession / abortSession: those maintain the recorder's
+ * localStorage crash-recovery marker, which a file upload must not
+ * touch. The slice POSTs go through XMLHttpRequest rather than fetch so
+ * the progress bar moves within a slice and not just between slices.
+ *
+ * File slices are Blob views, so nothing here holds the file in memory:
+ * a multi-gigabyte upload costs one slice's worth of buffering in the
+ * browser's network stack.
+ */
+
+import { getUploadCsrfToken, isCsrfRejection } from '../csrf.js';
+import { computeUploadTimeout } from '../utils/upload-timeout.js';
+
+const SESSION_BASE = '/upload/session';
+
+export const SLICE_BYTES = 16 * 1024 * 1024;
+
+const MAX_SLICE_ATTEMPTS = 6;
+const BASE_RETRY_MS = 1000;
+const MAX_RETRY_MS = 30000;
+
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+/** True when the file is large enough that slicing it is worth a session. */
+export function shouldSliceUpload(file) {
+    return !!file && file.size > SLICE_BYTES;
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const retryDelay = (attempts) =>
+    Math.min(MAX_RETRY_MS, BASE_RETRY_MS * Math.pow(2, attempts - 1));
+
+function parseJson(text) {
+    try { return JSON.parse(text); } catch (_) { return null; }
+}
+
+/**
+ * POST via XHR, resolving for every HTTP status so callers can decide
+ * what is retryable. Rejects only on a network error or timeout, where
+ * there is no status and a retry is the right answer.
+ */
+function xhrPost(url, body, { token, timeoutMs, onProgress, contentType, onXhr }) {
+    return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', url);
+        if (token) xhr.setRequestHeader('X-CSRFToken', token);
+        if (contentType) xhr.setRequestHeader('Content-Type', contentType);
+        xhr.timeout = timeoutMs;
+        if (onProgress) {
+            xhr.upload.onprogress = (e) => {
+                if (e.lengthComputable) onProgress(e.loaded, e.total);
+            };
+        }
+        xhr.onload = () => resolve({ status: xhr.status, text: xhr.responseText });
+        xhr.onerror = () => reject(new Error('Network error during upload'));
+        xhr.ontimeout = () => reject(new Error('Upload timed out'));
+        xhr.onabort = () => reject(new Error('Upload cancelled'));
+        if (onXhr) onXhr(xhr);
+        xhr.send(body);
+    });
+}
+
+async function createFileSession(file, token) {
+    const response = await fetch(SESSION_BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': token },
+        credentials: 'same-origin',
+        body: JSON.stringify({ filename: file.name, mime_type: file.type || '' }),
+    });
+    const body = parseJson(await response.text());
+    if (response.status !== 201 || !body?.session_id) {
+        throw new Error(body?.error || `Could not open upload session (HTTP ${response.status})`);
+    }
+    if (!body.upload_filename) {
+        throw new Error('Server does not support sliced uploads');
+    }
+    return body;
+}
+
+async function deleteFileSession(sessionId, token) {
+    try {
+        await fetch(`${SESSION_BASE}/${encodeURIComponent(sessionId)}`, {
+            method: 'DELETE',
+            credentials: 'same-origin',
+            headers: { 'X-CSRFToken': token },
+        });
+    } catch (error) {
+        console.warn('[SlicedUpload] Could not abort session:', error);
+    }
+}
+
+/**
+ * Send one slice, retrying transport failures and refreshing the CSRF
+ * token when the server rejects it. Returns the index the server expects
+ * next, which is normally `index + 1` but can jump when a 409 reveals
+ * the server already holds slices whose responses we lost.
+ */
+async function sendSlice(sessionId, index, blob, tokenRef, options) {
+    const url = `${SESSION_BASE}/${encodeURIComponent(sessionId)}/chunks/${index}`;
+    for (let attempt = 1; ; attempt++) {
+        let result;
+        try {
+            result = await xhrPost(url, blob, {
+                token: tokenRef.token,
+                timeoutMs: computeUploadTimeout(blob.size),
+                contentType: 'application/octet-stream',
+                onProgress: options.onSliceProgress,
+                onXhr: options.onXhr,
+            });
+        } catch (transportError) {
+            if (attempt >= MAX_SLICE_ATTEMPTS) throw transportError;
+            await sleep(retryDelay(attempt));
+            continue;
+        }
+
+        if (result.status === 204) return index + 1;
+
+        const body = parseJson(result.text);
+
+        if (result.status === 409 && Number.isInteger(body?.expected_chunk_index)) {
+            return body.expected_chunk_index;
+        }
+
+        if (isCsrfRejection(result.status, result.text) && attempt < MAX_SLICE_ATTEMPTS) {
+            tokenRef.token = await getUploadCsrfToken();
+            continue;
+        }
+
+        const error = new Error(sliceRejectionMessage(index, blob.size, result, body));
+        error.status = result.status;
+        if (!RETRYABLE_STATUSES.has(result.status) || attempt >= MAX_SLICE_ATTEMPTS) throw error;
+        await sleep(retryDelay(attempt));
+    }
+}
+
+/**
+ * A 413 on a slice is the reverse proxy, not Speakr: its body limit is
+ * below the slice size. Naming it the way a proxy does lets the upload
+ * composable's error mapping give the user the client_max_body_size
+ * guidance instead of a generic processing error.
+ */
+function sliceRejectionMessage(index, sliceSize, result, body) {
+    if (result.status === 413 && !body?.error) {
+        const megabytes = Math.round(sliceSize / (1024 * 1024));
+        return `Request entity too large: the reverse proxy rejected a ${megabytes} MB upload slice`;
+    }
+    return body?.error || `Slice ${index} rejected (HTTP ${result.status})`;
+}
+
+async function finalize(sessionId, formData, tokenRef, options) {
+    const url = `${SESSION_BASE}/${encodeURIComponent(sessionId)}/finalize-upload`;
+    for (let attempt = 1; ; attempt++) {
+        const result = await xhrPost(url, formData, {
+            token: tokenRef.token,
+            timeoutMs: options.finalizeTimeoutMs,
+            onXhr: options.onXhr,
+        });
+        const body = parseJson(result.text);
+        if (result.status === 202 && body?.id) return body;
+        if (isCsrfRejection(result.status, result.text) && attempt === 1) {
+            tokenRef.token = await getUploadCsrfToken();
+            continue;
+        }
+        throw new Error(body?.error
+            || `Upload could not be finalized (HTTP ${result.status})`);
+    }
+}
+
+/**
+ * Upload `file` in slices and finalize with `formData` (the same form the
+ * single-shot path builds, minus the file part). Resolves to the created
+ * recording, matching what POST /upload returns.
+ *
+ * `onProgress` is called with a 0..1 fraction of bytes accepted by the
+ * server. `onXhr` receives each in-flight XHR so a caller can cancel.
+ */
+export async function uploadFileInSlices(file, formData, options = {}) {
+    const tokenRef = { token: await getUploadCsrfToken() };
+    const session = await createFileSession(file, tokenRef.token);
+    const sliceBytes = Math.min(SLICE_BYTES, session.max_chunk_bytes || SLICE_BYTES);
+    const onProgress = options.onProgress || (() => {});
+
+    try {
+        let index = 1;
+        while ((index - 1) * sliceBytes < file.size) {
+            const start = (index - 1) * sliceBytes;
+            const end = Math.min(start + sliceBytes, file.size);
+            index = await sendSlice(session.session_id, index, file.slice(start, end), tokenRef, {
+                onXhr: options.onXhr,
+                onSliceProgress: (loaded) => onProgress(Math.min(1, (start + loaded) / file.size)),
+            });
+            onProgress(Math.min(1, ((index - 1) * sliceBytes) / file.size));
+        }
+        return await finalize(session.session_id, formData, tokenRef, {
+            finalizeTimeoutMs: computeUploadTimeout(file.size),
+            onXhr: options.onXhr,
+        });
+    } catch (error) {
+        await deleteFileSession(session.session_id, tokenRef.token);
+        throw error;
+    }
+}

--- a/static/js/modules/db/sliced-file-upload.js
+++ b/static/js/modules/db/sliced-file-upload.js
@@ -43,7 +43,9 @@ const MAX_STALLED_RESYNCS = 2;
 const BASE_RETRY_MS = 1000;
 const MAX_RETRY_MS = 30000;
 
-const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 527]);
+
+const INCONCLUSIVE_STATUSES = new Set([408, 429, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 527]);
 
 const RESUME_KEY = 'speakr.slicedUploads';
 const RESUME_TTL_MS = 24 * 60 * 60 * 1000;
@@ -279,12 +281,29 @@ function sliceRejectionMessage(index, sliceSize, result, body) {
 }
 
 /**
+ * True when the session has to outlive a failed finalize.
+ *
+ * Covers the statuses that leave the outcome unknown, and the 409 that
+ * says another request holds the finalize claim. Cloudflare answers 524
+ * at 125 seconds while the origin carries on ingesting, which is the
+ * case that matters: the retry is then the replay that hands back the
+ * recording rather than a second upload of the same file.
+ *
+ * Guessing wrong in this direction is cheap. The resume check reads the
+ * session's real state first and only continues one the server still
+ * has, so a session that did fail costs one request to discover it.
+ */
+function finalizeCouldStillLand(status) {
+    return INCONCLUSIVE_STATUSES.has(status) || status === 409;
+}
+
+/**
  * Turn the uploaded slices into a recording.
  *
- * A transport failure here is marked resumable: the server may be
- * ingesting at that moment, so the slices have to survive, and a retry
- * gets back the recording that call produced rather than sending the
- * file a second time.
+ * A transport failure or an inconclusive status here is marked resumable:
+ * the server may be ingesting at that moment, so the slices have to
+ * survive, and a retry gets back the recording that call produced rather
+ * than sending the file a second time.
  */
 async function finalize(sessionId, formData, tokenRef, options) {
     const url = `${SESSION_BASE}/${encodeURIComponent(sessionId)}/finalize-upload`;
@@ -306,8 +325,11 @@ async function finalize(sessionId, formData, tokenRef, options) {
             tokenRef.token = await getUploadCsrfToken();
             continue;
         }
-        throw new Error(body?.error
+        const error = new Error(body?.error
             || `Upload could not be finalized (HTTP ${result.status})`);
+        error.status = result.status;
+        error.resumable = finalizeCouldStillLand(result.status);
+        throw error;
     }
 }
 

--- a/static/js/modules/db/sliced-file-upload.js
+++ b/static/js/modules/db/sliced-file-upload.js
@@ -22,6 +22,13 @@
  * File slices are Blob views, so nothing here holds the file in memory:
  * a multi-gigabyte upload costs one slice's worth of buffering in the
  * browser's network stack.
+ *
+ * An upload interrupted by the network resumes rather than restarting:
+ * the session id is kept in localStorage under the file's identity
+ * (name, size, lastModified), and re-adding the same file continues from
+ * the slice count the server reports. Only a rejection the server will
+ * repeat (an oversize slice, an exhausted quota, a size mismatch) drops
+ * the session, because retrying it would fail the same way.
  */
 
 import { getUploadCsrfToken, isCsrfRejection } from '../csrf.js';
@@ -38,12 +45,103 @@ const MAX_RETRY_MS = 30000;
 
 const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
+const RESUME_KEY = 'speakr.slicedUploads';
+const RESUME_TTL_MS = 24 * 60 * 60 * 1000;
+const RESUME_MAX_ENTRIES = 20;
+
 /** True when the file is large enough that slicing it is worth a session. */
 export function shouldSliceUpload(file) {
     return !!file && file.size > SLICE_BYTES;
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Identity of the file on this machine. `lastModified` is in it so an
+ * edited or re-exported file of the same name and size is not resumed
+ * onto slices of the older one.
+ */
+function fileKey(file) {
+    return `${file.name}|${file.size}|${file.lastModified || 0}`;
+}
+
+/** Open sessions by file key. Best-effort: private mode has no store. */
+function readResumeMemory() {
+    try {
+        const parsed = JSON.parse(localStorage.getItem(RESUME_KEY) || '{}');
+        const fresh = {};
+        for (const [key, entry] of Object.entries(parsed)) {
+            if (entry?.sessionId && Date.now() - (entry.savedAt || 0) < RESUME_TTL_MS) {
+                fresh[key] = entry;
+            }
+        }
+        return fresh;
+    } catch (_) {
+        return {};
+    }
+}
+
+function writeResumeMemory(memory) {
+    try {
+        const entries = Object.entries(memory)
+            .sort((a, b) => (b[1].savedAt || 0) - (a[1].savedAt || 0))
+            .slice(0, RESUME_MAX_ENTRIES);
+        localStorage.setItem(RESUME_KEY, JSON.stringify(Object.fromEntries(entries)));
+    } catch (_) { /* private mode / quota: resuming is a bonus, not a requirement */ }
+}
+
+function rememberSession(file, sessionId, sliceBytes) {
+    const memory = readResumeMemory();
+    memory[fileKey(file)] = { sessionId, sliceBytes, savedAt: Date.now() };
+    writeResumeMemory(memory);
+}
+
+export function forgetSession(file) {
+    const memory = readResumeMemory();
+    delete memory[fileKey(file)];
+    writeResumeMemory(memory);
+}
+
+/**
+ * The server's view of a session we started for this file, when it can
+ * still be continued. Returns `{sessionId, sliceBytes, chunkCount}` or
+ * null, and forgets anything the server no longer recognises.
+ */
+async function resumableSession(file, token) {
+    const remembered = readResumeMemory()[fileKey(file)];
+    if (!remembered) return null;
+
+    let status;
+    try {
+        const response = await fetch(
+            `${SESSION_BASE}/${encodeURIComponent(remembered.sessionId)}`,
+            { credentials: 'same-origin', headers: { 'X-CSRFToken': token } });
+        if (!response.ok) {
+            forgetSession(file);
+            return null;
+        }
+        status = parseJson(await response.text());
+    } catch (error) {
+        console.warn('[SlicedUpload] Could not read the remembered session:', error);
+        return null;
+    }
+
+    const continuable = status
+        && status.kind === 'sliced_upload'
+        && status.upload_total_bytes === file.size
+        && ['recording', 'finalized'].includes(status.status)
+        && remembered.sliceBytes > 0;
+    if (!continuable) {
+        forgetSession(file);
+        return null;
+    }
+
+    return {
+        sessionId: remembered.sessionId,
+        sliceBytes: remembered.sliceBytes,
+        chunkCount: status.chunk_count || 0,
+    };
+}
 
 const retryDelay = (attempts) =>
     Math.min(MAX_RETRY_MS, BASE_RETRY_MS * Math.pow(2, attempts - 1));
@@ -116,6 +214,10 @@ async function deleteFileSession(sessionId, token) {
  * token when the server rejects it. Returns the index the server expects
  * next, which is normally `index + 1` but can jump when a 409 reveals
  * the server already holds slices whose responses we lost.
+ *
+ * Failures that outlive the retries are marked resumable when nothing
+ * about them says the next attempt would fail too: the transport, and
+ * the statuses a gateway returns while something behind it restarts.
  */
 async function sendSlice(sessionId, index, blob, tokenRef, options) {
     const url = `${SESSION_BASE}/${encodeURIComponent(sessionId)}/chunks/${index}`;
@@ -130,7 +232,10 @@ async function sendSlice(sessionId, index, blob, tokenRef, options) {
                 onXhr: options.onXhr,
             });
         } catch (transportError) {
-            if (attempt >= MAX_SLICE_ATTEMPTS) throw transportError;
+            if (attempt >= MAX_SLICE_ATTEMPTS) {
+                transportError.resumable = true;
+                throw transportError;
+            }
             await sleep(retryDelay(attempt));
             continue;
         }
@@ -150,7 +255,11 @@ async function sendSlice(sessionId, index, blob, tokenRef, options) {
 
         const error = new Error(sliceRejectionMessage(index, blob.size, result, body));
         error.status = result.status;
-        if (!RETRYABLE_STATUSES.has(result.status) || attempt >= MAX_SLICE_ATTEMPTS) throw error;
+        if (!RETRYABLE_STATUSES.has(result.status)) throw error;
+        if (attempt >= MAX_SLICE_ATTEMPTS) {
+            error.resumable = true;
+            throw error;
+        }
         await sleep(retryDelay(attempt));
     }
 }
@@ -169,14 +278,28 @@ function sliceRejectionMessage(index, sliceSize, result, body) {
     return body?.error || `Slice ${index} rejected (HTTP ${result.status})`;
 }
 
+/**
+ * Turn the uploaded slices into a recording.
+ *
+ * A transport failure here is marked resumable: the server may be
+ * ingesting at that moment, so the slices have to survive, and a retry
+ * gets back the recording that call produced rather than sending the
+ * file a second time.
+ */
 async function finalize(sessionId, formData, tokenRef, options) {
     const url = `${SESSION_BASE}/${encodeURIComponent(sessionId)}/finalize-upload`;
     for (let attempt = 1; ; attempt++) {
-        const result = await xhrPost(url, formData, {
-            token: tokenRef.token,
-            timeoutMs: options.finalizeTimeoutMs,
-            onXhr: options.onXhr,
-        });
+        let result;
+        try {
+            result = await xhrPost(url, formData, {
+                token: tokenRef.token,
+                timeoutMs: options.finalizeTimeoutMs,
+                onXhr: options.onXhr,
+            });
+        } catch (transportError) {
+            transportError.resumable = true;
+            throw transportError;
+        }
         const body = parseJson(result.text);
         if (result.status >= 200 && result.status < 300 && body?.id) return body;
         if (isCsrfRejection(result.status, result.text) && attempt === 1) {
@@ -193,23 +316,36 @@ async function finalize(sessionId, formData, tokenRef, options) {
  * single-shot path builds, minus the file part). Resolves to the created
  * recording, matching what POST /upload returns.
  *
+ * An interrupted upload of the same file continues where it stopped. A
+ * failure the server would repeat takes the session down with it; one
+ * that might not (the network, a timeout) leaves it for the next attempt.
+ *
  * `onProgress` is called with a 0..1 fraction of bytes accepted by the
  * server. `onXhr` receives each in-flight XHR so a caller can cancel.
  */
 export async function uploadFileInSlices(file, formData, options = {}) {
     const tokenRef = { token: await getUploadCsrfToken() };
-    const session = await createFileSession(file, tokenRef.token);
-    const sliceBytes = Math.min(SLICE_BYTES, session.max_chunk_bytes || SLICE_BYTES);
     const onProgress = options.onProgress || (() => {});
 
+    const resumed = await resumableSession(file, tokenRef.token);
+    let sessionId = resumed?.sessionId;
+    let sliceBytes = resumed?.sliceBytes;
+    if (!resumed) {
+        const created = await createFileSession(file, tokenRef.token);
+        sessionId = created.session_id;
+        sliceBytes = Math.min(SLICE_BYTES, created.max_chunk_bytes || SLICE_BYTES);
+        rememberSession(file, sessionId, sliceBytes);
+    }
+
     try {
-        let index = 1;
-        let highWaterMark = 0;
+        let index = (resumed?.chunkCount || 0) + 1;
+        let highWaterMark = index;
         let stalledResyncs = 0;
+        onProgress(Math.min(1, ((index - 1) * sliceBytes) / file.size));
         while ((index - 1) * sliceBytes < file.size) {
             const start = (index - 1) * sliceBytes;
             const end = Math.min(start + sliceBytes, file.size);
-            index = await sendSlice(session.session_id, index, file.slice(start, end), tokenRef, {
+            index = await sendSlice(sessionId, index, file.slice(start, end), tokenRef, {
                 onXhr: options.onXhr,
                 onSliceProgress: (loaded) => onProgress(Math.min(1, (start + loaded) / file.size)),
             });
@@ -223,12 +359,16 @@ export async function uploadFileInSlices(file, formData, options = {}) {
             }
             onProgress(Math.min(1, ((index - 1) * sliceBytes) / file.size));
         }
-        return await finalize(session.session_id, formData, tokenRef, {
+        const recording = await finalize(sessionId, formData, tokenRef, {
             finalizeTimeoutMs: computeUploadTimeout(file.size),
             onXhr: options.onXhr,
         });
+        forgetSession(file);
+        return recording;
     } catch (error) {
-        await deleteFileSession(session.session_id, tokenRef.token);
+        if (error.resumable) throw error;
+        await deleteFileSession(sessionId, tokenRef.token);
+        forgetSession(file);
         throw error;
     }
 }

--- a/static/js/modules/db/sliced-file-upload.test.js
+++ b/static/js/modules/db/sliced-file-upload.test.js
@@ -61,10 +61,11 @@ function _installMocks() {
             };
         }
         if (!options.method) {
+            const status = nextOf(sessionStatus);
             return {
-                status: sessionStatus ? 200 : 404,
-                ok: !!sessionStatus,
-                text: async () => JSON.stringify(sessionStatus || {}),
+                status: status ? 200 : 404,
+                ok: !!status,
+                text: async () => JSON.stringify(status || {}),
             };
         }
         return { status: 204, text: async () => '' };
@@ -85,7 +86,7 @@ function _installMocks() {
             const call = { url: this.url, body, headers: this.headers };
             sent.push(call);
             const response = this.url.endsWith('/finalize-upload')
-                ? finalizeResponse
+                ? nextOf(finalizeResponse)
                 : (sliceResponses.shift() || defaultSliceResponse);
             queueMicrotask(() => {
                 if (response.networkError) {
@@ -103,7 +104,14 @@ function _installMocks() {
     };
 }
 
+/** Queued answers are consumed in order; the last one repeats. */
+function nextOf(answers) {
+    if (!Array.isArray(answers)) return answers;
+    return answers.length > 1 ? answers.shift() : answers[0];
+}
+
 const slicePosts = () => sent.filter((call) => !call.url.endsWith('/finalize-upload'));
+const finalizePosts = () => sent.filter((call) => call.url.endsWith('/finalize-upload'));
 const createCalls = () => fetchCalls.filter((call) => call.options.method === 'POST');
 const deleteCalls = () => fetchCalls.filter((call) => call.options.method === 'DELETE');
 const rememberedSessions = () => JSON.parse(store.get('speakr.slicedUploads') || '{}');
@@ -314,26 +322,80 @@ describe('resuming an interrupted upload', () => {
         });
     });
 
-    // Cloudflare answers 524 at 125s while the origin is still ingesting, and the finalize it timed out on may well have landed.
-    it('keeps the session when the edge times the finalize out', async () => {
-        finalizeResponse = { status: 524, text: '<html><title>524: A timeout occurred</title></html>' };
+    const TIMED_OUT = { status: 524, text: '<html><title>524: A timeout occurred</title></html>' };
+    const INGESTED = { status: 202, text: JSON.stringify({ id: 42, title: 'talk', idempotent_replay: true }) };
+
+    // Cloudflare cuts the answer off at 125s while the origin finishes the ingest, so the recording exists and the client must not re-send the file.
+    it('waits out an ingest the edge timed out on and returns its recording', async () => {
+        vi.useFakeTimers();
+        finalizeResponse = [TIMED_OUT, INGESTED];
+        sessionStatus = [
+            { kind: 'sliced_upload', status: 'finalizing', chunk_count: 3, upload_total_bytes: 40 * MB },
+            { kind: 'sliced_upload', status: 'finalized', chunk_count: 3, upload_total_bytes: 40 * MB },
+        ];
+
+        const upload = uploadFileInSlices(fakeFile(40 * MB), new Map(), {});
+        await vi.advanceTimersByTimeAsync(10000);
+
+        expect(await upload).toMatchObject({ id: 42, idempotent_replay: true });
+        expect(slicePosts()).toHaveLength(3);
+        expect(finalizePosts()).toHaveLength(2);
+        expect(deleteCalls()).toHaveLength(0);
+        expect(rememberedSessions()).toEqual({});
+    });
+
+    it('finalizes for real when the timed-out request never reached Speakr', async () => {
+        vi.useFakeTimers();
+        finalizeResponse = [{ status: 502, text: 'Bad Gateway' },
+                            { status: 202, text: JSON.stringify({ id: 43 }) }];
+        sessionStatus = { kind: 'sliced_upload', status: 'recording', chunk_count: 3, upload_total_bytes: 40 * MB };
+
+        const upload = uploadFileInSlices(fakeFile(40 * MB), new Map(), {});
+        await vi.advanceTimersByTimeAsync(10000);
+
+        expect(await upload).toMatchObject({ id: 43 });
+        expect(slicePosts()).toHaveLength(3);
+    });
+
+    it('surfaces the timeout and keeps the session when the ingest never settles', async () => {
+        vi.useFakeTimers();
+        finalizeResponse = TIMED_OUT;
+        sessionStatus = { kind: 'sliced_upload', status: 'finalizing', chunk_count: 3, upload_total_bytes: 40 * MB };
         const file = fakeFile(40 * MB);
 
-        await expect(uploadFileInSlices(file, new Map(), {}))
-            .rejects.toThrow('HTTP 524');
+        const upload = uploadFileInSlices(file, new Map(), {});
+        const assertion = expect(upload).rejects.toThrow('HTTP 524');
+        await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+        await assertion;
 
         expect(deleteCalls()).toHaveLength(0);
         expect(rememberedSessions()[`talk.mp4|${40 * MB}|0`]).toMatchObject({ sessionId: 'sess-1' });
     });
 
-    it('keeps the session when another request already holds the finalize claim', async () => {
-        finalizeResponse = { status: 409, text: JSON.stringify({ error: 'Session is already being finalized' }) };
+    it('waits out an ingest that was already running when the file was added again', async () => {
+        vi.useFakeTimers();
+        const file = fakeFile(40 * MB);
+        finalizeResponse = TIMED_OUT;
+        sessionStatus = { kind: 'sliced_upload', status: 'finalizing', chunk_count: 3, upload_total_bytes: 40 * MB };
+        const abandoned = uploadFileInSlices(file, new Map(), {});
+        const abandonedAssertion = expect(abandoned).rejects.toThrow('HTTP 524');
+        await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+        await abandonedAssertion;
 
-        await expect(uploadFileInSlices(fakeFile(40 * MB), new Map(), {}))
-            .rejects.toThrow('already being finalized');
+        sent = [];
+        fetchCalls = [];
+        finalizeResponse = [{ status: 409, text: JSON.stringify({ error: 'Session is already being finalized' }) }, INGESTED];
+        sessionStatus = [
+            { kind: 'sliced_upload', status: 'finalizing', chunk_count: 3, upload_total_bytes: 40 * MB },
+            { kind: 'sliced_upload', status: 'finalized', chunk_count: 3, upload_total_bytes: 40 * MB },
+        ];
 
-        expect(deleteCalls()).toHaveLength(0);
-        expect(Object.keys(rememberedSessions())).toHaveLength(1);
+        const retry = uploadFileInSlices(file, new Map(), {});
+        await vi.advanceTimersByTimeAsync(10000);
+
+        expect(await retry).toMatchObject({ id: 42 });
+        expect(createCalls()).toHaveLength(0);
+        expect(slicePosts()).toHaveLength(0);
     });
 
     it('retries a slice the edge timed out instead of abandoning the upload', async () => {

--- a/static/js/modules/db/sliced-file-upload.test.js
+++ b/static/js/modules/db/sliced-file-upload.test.js
@@ -12,11 +12,12 @@ import { SLICE_BYTES, shouldSliceUpload, uploadFileInSlices } from './sliced-fil
 
 const MB = 1024 * 1024;
 
-function fakeFile(size, name = 'talk.mp4', type = 'video/mp4') {
+function fakeFile(size, name = 'talk.mp4', type = 'video/mp4', lastModified = 0) {
     return {
         name,
         type,
         size,
+        lastModified,
         slice: (start, end) => ({ size: end - start, start, end }),
     };
 }
@@ -25,15 +26,27 @@ let sent;
 let sliceResponses;
 let finalizeResponse;
 let fetchCalls;
+let sessionStatus;
+let defaultSliceResponse;
+let store;
 
 function _installMocks() {
     sent = [];
     fetchCalls = [];
     sliceResponses = [];
+    defaultSliceResponse = { status: 204, text: '' };
     finalizeResponse = { status: 202, text: JSON.stringify({ id: 42, title: 'talk' }) };
+    sessionStatus = null;
 
     global.window = { csrfManager: { refreshToken: async () => 'fresh-token' } };
     global.document = { querySelector: () => null };
+
+    store = new Map();
+    global.localStorage = {
+        getItem: (key) => (store.has(key) ? store.get(key) : null),
+        setItem: (key, value) => store.set(key, String(value)),
+        removeItem: (key) => store.delete(key),
+    };
 
     global.fetch = vi.fn(async (url, options) => {
         fetchCalls.push({ url, options });
@@ -45,6 +58,13 @@ function _installMocks() {
                     upload_filename: JSON.parse(options.body).filename,
                     max_chunk_bytes: SLICE_BYTES,
                 }),
+            };
+        }
+        if (!options.method) {
+            return {
+                status: sessionStatus ? 200 : 404,
+                ok: !!sessionStatus,
+                text: async () => JSON.stringify(sessionStatus || {}),
             };
         }
         return { status: 204, text: async () => '' };
@@ -66,7 +86,7 @@ function _installMocks() {
             sent.push(call);
             const response = this.url.endsWith('/finalize-upload')
                 ? finalizeResponse
-                : (sliceResponses.shift() || { status: 204, text: '' });
+                : (sliceResponses.shift() || defaultSliceResponse);
             queueMicrotask(() => {
                 if (response.networkError) {
                     this.onerror();
@@ -84,6 +104,9 @@ function _installMocks() {
 }
 
 const slicePosts = () => sent.filter((call) => !call.url.endsWith('/finalize-upload'));
+const createCalls = () => fetchCalls.filter((call) => call.options.method === 'POST');
+const deleteCalls = () => fetchCalls.filter((call) => call.options.method === 'DELETE');
+const rememberedSessions = () => JSON.parse(store.get('speakr.slicedUploads') || '{}');
 
 describe('shouldSliceUpload', () => {
     it('leaves files that fit one request on the single-shot path', () => {
@@ -102,6 +125,7 @@ describe('uploadFileInSlices', () => {
         delete global.XMLHttpRequest;
         delete global.window;
         delete global.document;
+        delete global.localStorage;
     });
 
     it('opens a session for the filename, sends whole slices in order, and finalizes', async () => {
@@ -245,5 +269,140 @@ describe('uploadFileInSlices', () => {
         await expect(uploadFileInSlices(fakeFile(20 * MB), new Map(), {}))
             .rejects.toThrow('Slices on disk do not match the session');
         expect(fetchCalls[fetchCalls.length - 1].options.method).toBe('DELETE');
+    });
+
+    it('forgets the session once the upload is finalized', async () => {
+        await uploadFileInSlices(fakeFile(20 * MB), new Map(), {});
+
+        expect(rememberedSessions()).toEqual({});
+    });
+});
+
+describe('resuming an interrupted upload', () => {
+    beforeEach(() => { _installMocks(); });
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+        delete global.fetch;
+        delete global.XMLHttpRequest;
+        delete global.window;
+        delete global.document;
+        delete global.localStorage;
+    });
+
+    const interrupt = async (file) => {
+        vi.useFakeTimers();
+        sliceResponses = [{ status: 204, text: '' }];
+        defaultSliceResponse = { networkError: true };
+        const upload = uploadFileInSlices(file, new Map(), {});
+        const assertion = expect(upload).rejects.toThrow('Network error');
+        await vi.advanceTimersByTimeAsync(120000);
+        await assertion;
+        vi.useRealTimers();
+        defaultSliceResponse = { status: 204, text: '' };
+    };
+
+    it('keeps the session and its slices when the network drops', async () => {
+        const file = fakeFile(40 * MB);
+
+        await interrupt(file);
+
+        expect(deleteCalls()).toHaveLength(0);
+        expect(rememberedSessions()[`talk.mp4|${40 * MB}|0`]).toMatchObject({
+            sessionId: 'sess-1',
+            sliceBytes: SLICE_BYTES,
+        });
+    });
+
+    it('keeps the session when a gateway error outlives the retries', async () => {
+        vi.useFakeTimers();
+        sliceResponses = [{ status: 204, text: '' }];
+        defaultSliceResponse = { status: 502, text: 'Bad Gateway' };
+
+        const upload = uploadFileInSlices(fakeFile(40 * MB), new Map(), {});
+        const assertion = expect(upload).rejects.toThrow('HTTP 502');
+        await vi.advanceTimersByTimeAsync(120000);
+        await assertion;
+
+        expect(deleteCalls()).toHaveLength(0);
+        expect(Object.keys(rememberedSessions())).toHaveLength(1);
+    });
+
+    it('sends only the slices the server is missing on the next attempt', async () => {
+        const file = fakeFile(40 * MB);
+        await interrupt(file);
+        sent = [];
+        fetchCalls = [];
+        sessionStatus = {
+            kind: 'sliced_upload',
+            status: 'recording',
+            chunk_count: 1,
+            upload_total_bytes: 40 * MB,
+        };
+
+        const progress = [];
+        const result = await uploadFileInSlices(file, new Map(), {
+            onProgress: (fraction) => progress.push(fraction),
+        });
+
+        expect(createCalls()).toHaveLength(0);
+        expect(slicePosts().map((call) => [call.url, call.body.start])).toEqual([
+            ['/upload/session/sess-1/chunks/2', SLICE_BYTES],
+            ['/upload/session/sess-1/chunks/3', 2 * SLICE_BYTES],
+        ]);
+        expect(progress[0]).toBeCloseTo(SLICE_BYTES / (40 * MB));
+        expect(result).toEqual({ id: 42, title: 'talk' });
+        expect(rememberedSessions()).toEqual({});
+    });
+
+    it('replays the recording when the upload had already been finalized', async () => {
+        const file = fakeFile(40 * MB);
+        await interrupt(file);
+        sent = [];
+        sessionStatus = {
+            kind: 'sliced_upload',
+            status: 'finalized',
+            chunk_count: 3,
+            upload_total_bytes: 40 * MB,
+        };
+        finalizeResponse = {
+            status: 202,
+            text: JSON.stringify({ id: 42, title: 'talk', idempotent_replay: true }),
+        };
+
+        const result = await uploadFileInSlices(file, new Map(), {});
+
+        expect(slicePosts()).toHaveLength(0);
+        expect(result.id).toBe(42);
+    });
+
+    it('starts over when the file is not the one the session was opened for', async () => {
+        await interrupt(fakeFile(40 * MB));
+        sent = [];
+        fetchCalls = [];
+        sessionStatus = {
+            kind: 'sliced_upload',
+            status: 'recording',
+            chunk_count: 1,
+            upload_total_bytes: 40 * MB,
+        };
+
+        await uploadFileInSlices(fakeFile(40 * MB, 'talk.mp4', 'video/mp4', 99), new Map(), {});
+
+        expect(createCalls()).toHaveLength(1);
+        expect(slicePosts()[0].body.start).toBe(0);
+    });
+
+    it('starts over when the server no longer has the session', async () => {
+        const file = fakeFile(40 * MB);
+        await interrupt(file);
+        sent = [];
+        fetchCalls = [];
+        sessionStatus = null;
+
+        await uploadFileInSlices(file, new Map(), {});
+
+        expect(createCalls()).toHaveLength(1);
+        expect(slicePosts()[0].body.start).toBe(0);
     });
 });

--- a/static/js/modules/db/sliced-file-upload.test.js
+++ b/static/js/modules/db/sliced-file-upload.test.js
@@ -61,11 +61,14 @@ function _installMocks() {
             };
         }
         if (!options.method) {
-            const status = nextOf(sessionStatus);
+            const answer = nextOf(sessionStatus);
+            if (answer?.httpStatus) {
+                return { status: answer.httpStatus, ok: false, text: async () => 'proxy error' };
+            }
             return {
-                status: status ? 200 : 404,
-                ok: !!status,
-                text: async () => JSON.stringify(status || {}),
+                status: answer ? 200 : 404,
+                ok: !!answer,
+                text: async () => JSON.stringify(answer || {}),
             };
         }
         return { status: 204, text: async () => '' };
@@ -342,6 +345,53 @@ describe('resuming an interrupted upload', () => {
         expect(finalizePosts()).toHaveLength(2);
         expect(deleteCalls()).toHaveLength(0);
         expect(rememberedSessions()).toEqual({});
+    });
+
+    // The wait runs while a proxy is misbehaving, so its errors are part of that outage, not an answer.
+    it('keeps waiting when the status endpoint itself is failing', async () => {
+        vi.useFakeTimers();
+        finalizeResponse = [TIMED_OUT, INGESTED];
+        sessionStatus = [
+            { httpStatus: 502 },
+            { httpStatus: 504 },
+            { kind: 'sliced_upload', status: 'finalizing', chunk_count: 3, upload_total_bytes: 40 * MB },
+            { kind: 'sliced_upload', status: 'finalized', chunk_count: 3, upload_total_bytes: 40 * MB },
+        ];
+
+        const upload = uploadFileInSlices(fakeFile(40 * MB), new Map(), {});
+        await vi.advanceTimersByTimeAsync(20000);
+
+        expect(await upload).toMatchObject({ id: 42 });
+        expect(deleteCalls()).toHaveLength(0);
+    });
+
+    it('gives up on the wait when the server says the session is gone', async () => {
+        vi.useFakeTimers();
+        finalizeResponse = TIMED_OUT;
+        sessionStatus = null;
+
+        const upload = uploadFileInSlices(fakeFile(40 * MB), new Map(), {});
+        const assertion = expect(upload).rejects.toThrow('HTTP 524');
+        await vi.advanceTimersByTimeAsync(10000);
+        await assertion;
+
+        expect(finalizePosts()).toHaveLength(1);
+    });
+
+    it('keeps polling when a second finalize is cut off as well', async () => {
+        vi.useFakeTimers();
+        finalizeResponse = [TIMED_OUT, TIMED_OUT, INGESTED];
+        sessionStatus = [
+            { kind: 'sliced_upload', status: 'recording', chunk_count: 3, upload_total_bytes: 40 * MB },
+            { kind: 'sliced_upload', status: 'finalizing', chunk_count: 3, upload_total_bytes: 40 * MB },
+            { kind: 'sliced_upload', status: 'finalized', chunk_count: 3, upload_total_bytes: 40 * MB },
+        ];
+
+        const upload = uploadFileInSlices(fakeFile(40 * MB), new Map(), {});
+        await vi.advanceTimersByTimeAsync(30000);
+
+        expect(await upload).toMatchObject({ id: 42 });
+        expect(finalizePosts()).toHaveLength(3);
     });
 
     it('finalizes for real when the timed-out request never reached Speakr', async () => {

--- a/static/js/modules/db/sliced-file-upload.test.js
+++ b/static/js/modules/db/sliced-file-upload.test.js
@@ -116,6 +116,7 @@ describe('uploadFileInSlices', () => {
         expect(JSON.parse(fetchCalls[0].options.body)).toEqual({
             filename: 'talk.mp4',
             mime_type: 'video/mp4',
+            total_bytes: 40 * MB,
         });
         expect(slicePosts().map((call) => call.url)).toEqual([
             '/upload/session/sess-1/chunks/1',
@@ -187,6 +188,29 @@ describe('uploadFileInSlices', () => {
             url: '/upload/session/sess-1',
             options: { method: 'DELETE' },
         });
+    });
+
+    // A server running RECORDING_SESSION_COMMIT_BATCH_SIZE > 1 rolls its slice bookkeeping back per request.
+    it('stops uploading when the server keeps asking for a slice it accepted', async () => {
+        vi.useFakeTimers();
+        global.XMLHttpRequest = class extends global.XMLHttpRequest {
+            send(body) {
+                sent.push({ url: this.url, body, headers: this.headers });
+                const accepted = this.url.endsWith('/chunks/1');
+                queueMicrotask(() => {
+                    this.status = accepted ? 204 : 409;
+                    this.responseText = accepted ? '' : JSON.stringify({ expected_chunk_index: 1 });
+                    this.onload();
+                });
+            }
+        };
+
+        const upload = uploadFileInSlices(fakeFile(40 * MB), new Map(), {});
+        const assertion = expect(upload).rejects.toThrow('bookkeeping is not advancing');
+        await vi.advanceTimersByTimeAsync(60000);
+        await assertion;
+
+        expect(slicePosts().length).toBeLessThan(10);
     });
 
     it('blames the reverse proxy for a 413 with no Speakr error body', async () => {

--- a/static/js/modules/db/sliced-file-upload.test.js
+++ b/static/js/modules/db/sliced-file-upload.test.js
@@ -1,0 +1,225 @@
+/**
+ * Vitest tests for the sliced file-upload transport.
+ *
+ * The interesting code is the slice loop: fixed-size offsets, in-order
+ * indexes, retry, 409 resync, and cleaning up the session when the upload
+ * cannot continue. HTTP is exercised through fetch and XMLHttpRequest
+ * mocks.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SLICE_BYTES, shouldSliceUpload, uploadFileInSlices } from './sliced-file-upload.js';
+
+const MB = 1024 * 1024;
+
+function fakeFile(size, name = 'talk.mp4', type = 'video/mp4') {
+    return {
+        name,
+        type,
+        size,
+        slice: (start, end) => ({ size: end - start, start, end }),
+    };
+}
+
+let sent;
+let sliceResponses;
+let finalizeResponse;
+let fetchCalls;
+
+function _installMocks() {
+    sent = [];
+    fetchCalls = [];
+    sliceResponses = [];
+    finalizeResponse = { status: 202, text: JSON.stringify({ id: 42, title: 'talk' }) };
+
+    global.window = { csrfManager: { refreshToken: async () => 'fresh-token' } };
+    global.document = { querySelector: () => null };
+
+    global.fetch = vi.fn(async (url, options) => {
+        fetchCalls.push({ url, options });
+        if (options.method === 'POST') {
+            return {
+                status: 201,
+                text: async () => JSON.stringify({
+                    session_id: 'sess-1',
+                    upload_filename: JSON.parse(options.body).filename,
+                    max_chunk_bytes: SLICE_BYTES,
+                }),
+            };
+        }
+        return { status: 204, text: async () => '' };
+    });
+
+    global.XMLHttpRequest = class {
+        constructor() {
+            this.upload = {};
+            this.timeout = 0;
+            this.headers = {};
+        }
+
+        open(method, url) { this.url = url; }
+
+        setRequestHeader(key, value) { this.headers[key] = value; }
+
+        send(body) {
+            const call = { url: this.url, body, headers: this.headers };
+            sent.push(call);
+            const response = this.url.endsWith('/finalize-upload')
+                ? finalizeResponse
+                : (sliceResponses.shift() || { status: 204, text: '' });
+            queueMicrotask(() => {
+                if (response.networkError) {
+                    this.onerror();
+                    return;
+                }
+                if (this.upload.onprogress && body?.size) {
+                    this.upload.onprogress({ lengthComputable: true, loaded: body.size, total: body.size });
+                }
+                this.status = response.status;
+                this.responseText = response.text ?? '';
+                this.onload();
+            });
+        }
+    };
+}
+
+const slicePosts = () => sent.filter((call) => !call.url.endsWith('/finalize-upload'));
+
+describe('shouldSliceUpload', () => {
+    it('leaves files that fit one request on the single-shot path', () => {
+        expect(shouldSliceUpload(fakeFile(SLICE_BYTES))).toBe(false);
+        expect(shouldSliceUpload(fakeFile(SLICE_BYTES + 1))).toBe(true);
+        expect(shouldSliceUpload(null)).toBe(false);
+    });
+});
+
+describe('uploadFileInSlices', () => {
+    beforeEach(() => { _installMocks(); });
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+        delete global.fetch;
+        delete global.XMLHttpRequest;
+        delete global.window;
+        delete global.document;
+    });
+
+    it('opens a session for the filename, sends whole slices in order, and finalizes', async () => {
+        const file = fakeFile(40 * MB);
+        const form = new Map([['title', 'Sliced']]);
+        const progress = [];
+
+        const result = await uploadFileInSlices(file, form, {
+            onProgress: (fraction) => progress.push(fraction),
+        });
+
+        expect(JSON.parse(fetchCalls[0].options.body)).toEqual({
+            filename: 'talk.mp4',
+            mime_type: 'video/mp4',
+        });
+        expect(slicePosts().map((call) => call.url)).toEqual([
+            '/upload/session/sess-1/chunks/1',
+            '/upload/session/sess-1/chunks/2',
+            '/upload/session/sess-1/chunks/3',
+        ]);
+        expect(slicePosts().map((call) => call.body.size)).toEqual([SLICE_BYTES, SLICE_BYTES, 8 * MB]);
+        expect(slicePosts()[0].headers['X-CSRFToken']).toBe('fresh-token');
+
+        const finalizeCall = sent[sent.length - 1];
+        expect(finalizeCall.url).toBe('/upload/session/sess-1/finalize-upload');
+        expect(finalizeCall.body).toBe(form);
+        expect(result).toEqual({ id: 42, title: 'talk' });
+        expect(progress[progress.length - 1]).toBe(1);
+    });
+
+    it('honours a lower max_chunk_bytes from the server', async () => {
+        global.fetch = vi.fn(async (url, options) => ({
+            status: 201,
+            text: async () => JSON.stringify({
+                session_id: 'sess-1',
+                upload_filename: 'talk.mp4',
+                max_chunk_bytes: 4 * MB,
+            }),
+        }));
+
+        await uploadFileInSlices(fakeFile(10 * MB), new Map(), {});
+
+        expect(slicePosts().map((call) => call.body.size)).toEqual([4 * MB, 4 * MB, 2 * MB]);
+    });
+
+    it('resends the same offset after a network error', async () => {
+        vi.useFakeTimers();
+        sliceResponses = [{ networkError: true }];
+
+        const upload = uploadFileInSlices(fakeFile(20 * MB), new Map(), {});
+        await vi.advanceTimersByTimeAsync(2000);
+        await upload;
+
+        expect(slicePosts().map((call) => [call.url, call.body.start])).toEqual([
+            ['/upload/session/sess-1/chunks/1', 0],
+            ['/upload/session/sess-1/chunks/1', 0],
+            ['/upload/session/sess-1/chunks/2', SLICE_BYTES],
+        ]);
+    });
+
+    it('skips ahead when a 409 says the server already holds the slice', async () => {
+        sliceResponses = [{ status: 409, text: JSON.stringify({ expected_chunk_index: 3 }) }];
+
+        await uploadFileInSlices(fakeFile(40 * MB), new Map(), {});
+
+        expect(slicePosts().map((call) => [call.url, call.body.start])).toEqual([
+            ['/upload/session/sess-1/chunks/1', 0],
+            ['/upload/session/sess-1/chunks/3', 2 * SLICE_BYTES],
+        ]);
+    });
+
+    it('gives up on a rejected slice and deletes the half-uploaded session', async () => {
+        sliceResponses = [
+            { status: 204, text: '' },
+            { status: 413, text: JSON.stringify({ error: 'Chunk exceeds max_chunk_bytes' }) },
+        ];
+
+        await expect(uploadFileInSlices(fakeFile(40 * MB), new Map(), {}))
+            .rejects.toThrow('Chunk exceeds max_chunk_bytes');
+
+        expect(slicePosts()).toHaveLength(2);
+        expect(fetchCalls[fetchCalls.length - 1]).toMatchObject({
+            url: '/upload/session/sess-1',
+            options: { method: 'DELETE' },
+        });
+    });
+
+    it('blames the reverse proxy for a 413 with no Speakr error body', async () => {
+        sliceResponses = [{ status: 413, text: '<html><head><title>413 Request Entity Too Large</title></head></html>' }];
+
+        await expect(uploadFileInSlices(fakeFile(40 * MB), new Map(), {}))
+            .rejects.toThrow('Request entity too large: the reverse proxy rejected a 16 MB upload slice');
+    });
+
+    it('retries a slice with a fresh token when the server rejects the CSRF one', async () => {
+        sliceResponses = [{ status: 400, text: 'The CSRF token has expired.' }];
+
+        await uploadFileInSlices(fakeFile(20 * MB), new Map(), {});
+
+        expect(slicePosts().map((call) => call.body.start)).toEqual([0, 0, SLICE_BYTES]);
+    });
+
+    it('refuses to upload when the server does not understand sliced uploads', async () => {
+        global.fetch = vi.fn(async () => ({
+            status: 201,
+            text: async () => JSON.stringify({ session_id: 'sess-1', mime_type: 'audio/webm' }),
+        }));
+
+        await expect(uploadFileInSlices(fakeFile(20 * MB), new Map(), {}))
+            .rejects.toThrow('does not support sliced uploads');
+        expect(sent).toHaveLength(0);
+    });
+
+    it('surfaces the finalize error and deletes the session', async () => {
+        finalizeResponse = { status: 409, text: JSON.stringify({ error: 'Slices on disk do not match the session' }) };
+
+        await expect(uploadFileInSlices(fakeFile(20 * MB), new Map(), {}))
+            .rejects.toThrow('Slices on disk do not match the session');
+        expect(fetchCalls[fetchCalls.length - 1].options.method).toBe('DELETE');
+    });
+});

--- a/static/js/modules/db/sliced-file-upload.test.js
+++ b/static/js/modules/db/sliced-file-upload.test.js
@@ -264,10 +264,10 @@ describe('uploadFileInSlices', () => {
     });
 
     it('surfaces the finalize error and deletes the session', async () => {
-        finalizeResponse = { status: 409, text: JSON.stringify({ error: 'Slices on disk do not match the session' }) };
+        finalizeResponse = { status: 400, text: JSON.stringify({ error: 'No file provided' }) };
 
         await expect(uploadFileInSlices(fakeFile(20 * MB), new Map(), {}))
-            .rejects.toThrow('Slices on disk do not match the session');
+            .rejects.toThrow('No file provided');
         expect(fetchCalls[fetchCalls.length - 1].options.method).toBe('DELETE');
     });
 
@@ -312,6 +312,48 @@ describe('resuming an interrupted upload', () => {
             sessionId: 'sess-1',
             sliceBytes: SLICE_BYTES,
         });
+    });
+
+    // Cloudflare answers 524 at 125s while the origin is still ingesting, and the finalize it timed out on may well have landed.
+    it('keeps the session when the edge times the finalize out', async () => {
+        finalizeResponse = { status: 524, text: '<html><title>524: A timeout occurred</title></html>' };
+        const file = fakeFile(40 * MB);
+
+        await expect(uploadFileInSlices(file, new Map(), {}))
+            .rejects.toThrow('HTTP 524');
+
+        expect(deleteCalls()).toHaveLength(0);
+        expect(rememberedSessions()[`talk.mp4|${40 * MB}|0`]).toMatchObject({ sessionId: 'sess-1' });
+    });
+
+    it('keeps the session when another request already holds the finalize claim', async () => {
+        finalizeResponse = { status: 409, text: JSON.stringify({ error: 'Session is already being finalized' }) };
+
+        await expect(uploadFileInSlices(fakeFile(40 * MB), new Map(), {}))
+            .rejects.toThrow('already being finalized');
+
+        expect(deleteCalls()).toHaveLength(0);
+        expect(Object.keys(rememberedSessions())).toHaveLength(1);
+    });
+
+    it('retries a slice the edge timed out instead of abandoning the upload', async () => {
+        vi.useFakeTimers();
+        sliceResponses = [
+            { status: 204, text: '' },
+            { status: 524, text: '<html><title>524: A timeout occurred</title></html>' },
+        ];
+
+        const upload = uploadFileInSlices(fakeFile(40 * MB), new Map(), {});
+        await vi.advanceTimersByTimeAsync(5000);
+        await upload;
+
+        expect(slicePosts().map((call) => [call.url, call.body.start])).toEqual([
+            ['/upload/session/sess-1/chunks/1', 0],
+            ['/upload/session/sess-1/chunks/2', SLICE_BYTES],
+            ['/upload/session/sess-1/chunks/2', SLICE_BYTES],
+            ['/upload/session/sess-1/chunks/3', 2 * SLICE_BYTES],
+        ]);
+        expect(deleteCalls()).toHaveLength(0);
     });
 
     it('keeps the session when a gateway error outlives the retries', async () => {

--- a/tests/test_recording_stitch.py
+++ b/tests/test_recording_stitch.py
@@ -37,7 +37,7 @@ from src.models import User, Recording, RecordingSession
 from src.services.recording_stitch import (
     stitch_recording_session,
     StitchError,
-    _chunk_paths,
+    session_chunk_paths,
     _mime_to_extension,
     _chunk_starts_segment,
     _partition_into_segments,
@@ -208,7 +208,7 @@ def test_chunk_paths_returns_sorted_chunks():
             f.write(b'{}')
         with open(os.path.join(tmp, 'chunk-bad.txt'), 'wb') as f:
             f.write(b'.')
-        paths = _chunk_paths(tmp)
+        paths = session_chunk_paths(tmp)
         assert [os.path.basename(p) for p in paths] == ['chunk-000001.bin', 'chunk-000002.bin', 'chunk-000003.bin']
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -217,7 +217,7 @@ def test_chunk_paths_returns_sorted_chunks():
 def test_chunk_paths_empty_dir_returns_empty_list():
     tmp = tempfile.mkdtemp(prefix="speakr-stitch-empty-")
     try:
-        assert _chunk_paths(tmp) == []
+        assert session_chunk_paths(tmp) == []
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 

--- a/tests/test_sliced_file_upload.py
+++ b/tests/test_sliced_file_upload.py
@@ -402,6 +402,48 @@ def test_an_interrupted_sliced_upload_resumes_from_the_slices_already_sent():
     shutil.rmtree(upload_folder, ignore_errors=True)
 
 
+def test_a_finalize_abandoned_by_a_dead_worker_can_be_taken_over():
+    """Recreating the container mid-ingest leaves the session finalizing
+    with nobody ingesting. Without a takeover the user's retry waits for
+    a worker that no longer exists until the TTL sweep, a day later."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_takeover")
+        client = app.test_client()
+        _login(client, user)
+
+        payload = _payload(SLICE_BYTES)
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg",
+                                   total_bytes=len(payload))["session_id"]
+        _send_slices(client, session_id, payload)
+
+        session = db.session.get(RecordingSession, session_id)
+        session.status = "finalizing"
+        session.last_seen_at = datetime.utcnow()
+        db.session.commit()
+
+        fresh_claim = client.post(f"/upload/session/{session_id}/finalize-upload",
+                                  data={}, content_type="multipart/form-data")
+        assert fresh_claim.status_code == 409
+        assert "already being finalized" in fresh_claim.get_json()["error"]
+
+        session.last_seen_at = datetime.utcnow() - timedelta(hours=1)
+        db.session.commit()
+
+        staging = os.path.join(upload_folder, f"stg_{uuid.uuid4().hex[:6]}")
+        with _upload_mocks(staging):
+            taken_over = client.post(f"/upload/session/{session_id}/finalize-upload",
+                                     data={}, content_type="multipart/form-data")
+
+        assert taken_over.status_code == 202, taken_over.data
+        recording = db.session.get(Recording, taken_over.get_json()["id"])
+        assert recording.file_hash == hashlib.sha256(payload).hexdigest()
+
+        _cleanup(recording, user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
 def test_another_user_cannot_finalize_someone_elses_sliced_upload():
     upload_folder = _tmp_upload_folder()
     with app.app_context():

--- a/tests/test_sliced_file_upload.py
+++ b/tests/test_sliced_file_upload.py
@@ -20,6 +20,7 @@ import os
 import shutil
 import sys
 import tempfile
+import threading
 import uuid
 from datetime import datetime, timedelta
 from unittest.mock import patch
@@ -28,7 +29,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.app import app, db
 from src.models import Recording, RecordingSession
-from src.api.recording_sessions import cleanup_expired_sessions
+from src.api.recording_sessions import (
+    _beat_until_stopped,
+    _ingest_heartbeat_seconds,
+    cleanup_expired_sessions,
+)
 
 from tests.test_cov_recordings_write import _cleanup, _mk_user, _upload_mocks
 from tests.test_recording_sessions import _login
@@ -402,6 +407,37 @@ def test_an_interrupted_sliced_upload_resumes_from_the_slices_already_sent():
     shutil.rmtree(upload_folder, ignore_errors=True)
 
 
+def test_an_ingest_stamps_the_session_it_is_working_on():
+    """The stamp is the only liveness signal there is: under gunicorn's
+    gthread worker no timeout aborts a request, so a session in
+    'finalizing' says nothing about whether anyone is still ingesting
+    it."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_beat")
+        client = app.test_client()
+        _login(client, user)
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+
+        session = db.session.get(RecordingSession, session_id)
+        session.status = "finalizing"
+        went_quiet_at = datetime.utcnow() - timedelta(minutes=5)
+        session.last_seen_at = went_quiet_at
+        db.session.commit()
+
+        stop = threading.Event()
+        stop.set()
+        _beat_until_stopped(app, session_id, stop, interval=999)
+
+        db.session.expire_all()
+        assert db.session.get(RecordingSession, session_id).last_seen_at > went_quiet_at
+
+        client.delete(f"/upload/session/{session_id}")
+        _cleanup(user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
 def test_a_finalize_abandoned_by_a_dead_worker_can_be_taken_over():
     """Recreating the container mid-ingest leaves the session finalizing
     with nobody ingesting. Without a takeover the user's retry waits for
@@ -418,9 +454,10 @@ def test_a_finalize_abandoned_by_a_dead_worker_can_be_taken_over():
                                    total_bytes=len(payload))["session_id"]
         _send_slices(client, session_id, payload)
 
+        heartbeat = _ingest_heartbeat_seconds()
         session = db.session.get(RecordingSession, session_id)
         session.status = "finalizing"
-        session.last_seen_at = datetime.utcnow()
+        session.last_seen_at = datetime.utcnow() - timedelta(seconds=heartbeat * 2)
         db.session.commit()
 
         fresh_claim = client.post(f"/upload/session/{session_id}/finalize-upload",
@@ -428,7 +465,7 @@ def test_a_finalize_abandoned_by_a_dead_worker_can_be_taken_over():
         assert fresh_claim.status_code == 409
         assert "already being finalized" in fresh_claim.get_json()["error"]
 
-        session.last_seen_at = datetime.utcnow() - timedelta(hours=1)
+        session.last_seen_at = datetime.utcnow() - timedelta(seconds=heartbeat * 4)
         db.session.commit()
 
         staging = os.path.join(upload_folder, f"stg_{uuid.uuid4().hex[:6]}")

--- a/tests/test_sliced_file_upload.py
+++ b/tests/test_sliced_file_upload.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import uuid
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -45,8 +46,12 @@ def _payload(size):
     return bytes(range(256)) * (size // 256) + b"\xab" * (size % 256)
 
 
-def _open_session(client, filename="talk.mp4", mime_type="video/mp4"):
-    response = client.post("/upload/session", json={"filename": filename, "mime_type": mime_type})
+def _open_session(client, filename="talk.mp4", mime_type="video/mp4", total_bytes=SLICE_BYTES):
+    response = client.post("/upload/session", json={
+        "filename": filename,
+        "mime_type": mime_type,
+        "total_bytes": total_bytes,
+    })
     assert response.status_code == 201, response.data
     return response.get_json()
 
@@ -69,9 +74,13 @@ def test_create_session_with_filename_marks_it_a_file_upload():
         client = app.test_client()
         _login(client, user)
 
-        body = _open_session(client)
+        body = _open_session(client, total_bytes=4096)
+        assert body["kind"] == "sliced_upload"
         assert body["upload_filename"] == "talk.mp4"
-        assert db.session.get(RecordingSession, body["session_id"]).upload_filename == "talk.mp4"
+        session = db.session.get(RecordingSession, body["session_id"])
+        assert session.is_sliced_upload
+        assert session.upload_filename == "talk.mp4"
+        assert session.upload_total_bytes == 4096
 
         client.delete(f"/upload/session/{body['session_id']}")
         _cleanup(user)
@@ -94,6 +103,9 @@ def test_create_session_with_filename_skips_the_recorder_mime_whitelist():
         accepted = _open_session(client, filename="lecture.mkv", mime_type="video/x-matroska")
         assert accepted["mime_type"] == "video/x-matroska"
 
+        no_size = client.post("/upload/session", json={"filename": "lecture.mkv"})
+        assert no_size.status_code == 400
+
         client.delete(f"/upload/session/{accepted['session_id']}")
         _cleanup(user)
     shutil.rmtree(upload_folder, ignore_errors=True)
@@ -108,7 +120,8 @@ def test_finalize_upload_ingests_the_reassembled_original_bytes():
         _login(client, user)
 
         payload = _payload(SLICE_BYTES * 3 + 17)
-        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg",
+                                   total_bytes=len(payload))["session_id"]
         _send_slices(client, session_id, payload)
 
         staging = os.path.join(upload_folder, f"stg_{uuid.uuid4().hex[:6]}")
@@ -143,7 +156,8 @@ def test_finalize_upload_carries_the_upload_form_through_ingestion():
         client = app.test_client()
         _login(client, user)
 
-        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg",
+                                   total_bytes=SLICE_BYTES * 2)["session_id"]
         _send_slices(client, session_id, _payload(SLICE_BYTES * 2))
 
         staging = os.path.join(upload_folder, f"stg_{uuid.uuid4().hex[:6]}")
@@ -164,29 +178,88 @@ def test_finalize_upload_carries_the_upload_form_through_ingestion():
     shutil.rmtree(upload_folder, ignore_errors=True)
 
 
-def test_finalize_upload_rejects_a_slice_count_that_disagrees_with_disk():
-    """A slice lost between the write and the bookkeeping commit would
-    otherwise be silently ingested as a truncated file."""
+def test_finalize_upload_rejects_slices_that_do_not_weigh_the_declared_size():
+    """A missing or short slice would otherwise be ingested as a truncated
+    file, which ffprobe accepts for most containers, so the user would get
+    a silently broken recording instead of an error."""
     upload_folder = _tmp_upload_folder()
     with app.app_context():
         app.config["UPLOAD_FOLDER"] = upload_folder
-        user = _mk_user("slice_short")
+        client = app.test_client()
+
+        for label, damage in (
+            ("missing", lambda path: os.remove(path)),
+            ("truncated", lambda path: open(path, "wb").write(b"short")),
+        ):
+            user = _mk_user(f"slice_{label}")
+            _login(client, user)
+            session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg",
+                                       total_bytes=SLICE_BYTES * 2)["session_id"]
+            _send_slices(client, session_id, _payload(SLICE_BYTES * 2))
+            damage(os.path.join(upload_folder, "_sessions", session_id, "chunk-000002.bin"))
+
+            response = client.post(
+                f"/upload/session/{session_id}/finalize-upload",
+                data={},
+                content_type="multipart/form-data",
+            )
+            assert response.status_code == 409, (label, response.data)
+            assert response.get_json()["expected_bytes"] == SLICE_BYTES * 2
+            assert Recording.query.filter_by(user_id=user.id).count() == 0
+            _cleanup(user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_a_failed_finalize_upload_reclaims_the_slices_it_cannot_use():
+    """Finalize only accepts a session in 'recording' and no sweep collects
+    a terminal one, so slices left behind here leak the whole file until an
+    operator notices, the common cause being the disk that just filled."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_reclaim")
         client = app.test_client()
         _login(client, user)
 
         session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
-        _send_slices(client, session_id, _payload(SLICE_BYTES * 2))
-        os.remove(os.path.join(upload_folder, "_sessions", session_id, "chunk-000002.bin"))
+        _send_slices(client, session_id, _payload(SLICE_BYTES))
 
-        response = client.post(
-            f"/upload/session/{session_id}/finalize-upload",
-            data={},
-            content_type="multipart/form-data",
-        )
+        with patch("src.api.recording_sessions.byte_join",
+                   side_effect=OSError("No space left on device")):
+            response = client.post(
+                f"/upload/session/{session_id}/finalize-upload",
+                data={}, content_type="multipart/form-data")
+
+        assert response.status_code == 500
+        assert db.session.get(RecordingSession, session_id).status == "failed"
+        assert not os.path.isdir(os.path.join(upload_folder, "_sessions", session_id))
+
+        _cleanup(user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_a_finalize_upload_cannot_be_aborted_while_it_is_ingesting():
+    """The slices are being read in-request, so honouring the abort would
+    delete the ingesting file out from under the request."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_abort")
+        client = app.test_client()
+        _login(client, user)
+
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        _send_slices(client, session_id, _payload(SLICE_BYTES))
+        session = db.session.get(RecordingSession, session_id)
+        session.status = "finalizing"
+        db.session.commit()
+
+        response = client.delete(f"/upload/session/{session_id}")
         assert response.status_code == 409
-        assert response.get_json()["expected_chunk_index"] == 2
+        assert os.path.isdir(os.path.join(upload_folder, "_sessions", session_id))
 
-        client.delete(f"/upload/session/{session_id}")
+        session.status = "aborted"
+        db.session.commit()
         _cleanup(user)
     shutil.rmtree(upload_folder, ignore_errors=True)
 
@@ -254,9 +327,10 @@ def test_cleanup_expires_an_abandoned_sliced_upload_instead_of_assembling_it():
     shutil.rmtree(upload_folder, ignore_errors=True)
 
 
-def test_a_replayed_finalize_upload_does_not_ingest_the_file_twice():
+def test_a_replayed_finalize_upload_returns_the_first_call_s_recording():
     """Finalize is synchronous, so a client that retries it after a lost
-    response would otherwise land the same file in the library twice."""
+    response would otherwise be told 409 and re-upload the whole file it
+    had already delivered."""
     upload_folder = _tmp_upload_folder()
     with app.app_context():
         app.config["UPLOAD_FOLDER"] = upload_folder
@@ -275,7 +349,9 @@ def test_a_replayed_finalize_upload_does_not_ingest_the_file_twice():
                                  data={}, content_type="multipart/form-data")
 
         assert first.status_code == 202, first.data
-        assert second.status_code == 409
+        assert second.status_code == 202, second.data
+        assert second.get_json()["id"] == first.get_json()["id"]
+        assert second.get_json()["idempotent_replay"] is True
         assert Recording.query.filter_by(user_id=user.id).count() == 1
 
         _cleanup(db.session.get(Recording, first.get_json()["id"]), user)
@@ -303,3 +379,50 @@ def test_another_user_cannot_finalize_someone_elses_sliced_upload():
         client.delete(f"/upload/session/{session_id}")
         _cleanup(owner, intruder)
     shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_an_existing_recorder_session_survives_the_migration_as_a_recorder_session():
+    """The migration adds the discriminator to a table that already holds
+    live recorder sessions. If they came out the other side looking like
+    sliced uploads, /finalize would refuse them and the cleanup sweep would
+    stop rescuing abandoned recordings, which is the one thing that policy
+    exists to prevent."""
+    import sqlite3
+    from flask import Flask
+    from sqlalchemy import inspect
+    from src.init_db import initialize_database
+
+    fixture = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                           "fixtures", "schemas", "v0.10.3-alpha.sql")
+    db_dir = tempfile.mkdtemp(prefix="speakr-test-upgrade-")
+    db_path = os.path.join(db_dir, "old.db")
+
+    con = sqlite3.connect(db_path)
+    with open(fixture) as f:
+        con.executescript(f.read())
+    con.execute('INSERT INTO "user" (id, username, email, password) VALUES (1, "u", "u@local.test", "h")')
+    con.execute(
+        "INSERT INTO recording_session"
+        " (id, user_id, mime_type, status, chunk_count, bytes_received, created_at, last_seen_at)"
+        " VALUES ('sess-old', 1, 'audio/webm', 'recording', 7, 4096, '2026-01-01', '2026-01-01')"
+    )
+    con.commit()
+    con.close()
+
+    upgrading = Flask("upgrade_sliced_upload")
+    upgrading.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_path}"
+    upgrading.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    upgrading.config["UPLOAD_FOLDER"] = db_dir
+    db.init_app(upgrading)
+    with upgrading.app_context():
+        initialize_database(upgrading)
+        columns = {c["name"] for c in inspect(db.engine).get_columns("recording_session")}
+        survivor = db.session.get(RecordingSession, "sess-old")
+
+        assert {"kind", "upload_filename", "upload_total_bytes"} <= columns
+        assert survivor.chunk_count == 7
+        assert survivor.bytes_received == 4096
+        assert survivor.kind == "recorder"
+        assert survivor.is_sliced_upload is False
+
+    shutil.rmtree(db_dir, ignore_errors=True)

--- a/tests/test_sliced_file_upload.py
+++ b/tests/test_sliced_file_upload.py
@@ -32,6 +32,7 @@ from src.models import Recording, RecordingSession
 from src.api.recording_sessions import (
     _beat_until_stopped,
     _ingest_heartbeat_seconds,
+    _touch_session,
     cleanup_expired_sessions,
 )
 
@@ -434,6 +435,34 @@ def test_an_ingest_stamps_the_session_it_is_working_on():
         assert db.session.get(RecordingSession, session_id).last_seen_at > went_quiet_at
 
         client.delete(f"/upload/session/{session_id}")
+        _cleanup(user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_a_stamp_that_arrives_late_cannot_revive_a_finished_session():
+    """The heartbeat is stopped and joined with a timeout, so a beat can
+    still be in flight when the ingest publishes. Stamping only a
+    'finalizing' row is what keeps that beat from resurrecting a session
+    the sweep and the status endpoint have both moved on from."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_latebeat")
+        client = app.test_client()
+        _login(client, user)
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+
+        session = db.session.get(RecordingSession, session_id)
+        session.status = "finalized"
+        published_at = datetime.utcnow() - timedelta(minutes=5)
+        session.last_seen_at = published_at
+        db.session.commit()
+
+        _touch_session(app, session_id)
+
+        db.session.expire_all()
+        assert db.session.get(RecordingSession, session_id).last_seen_at == published_at
+
         _cleanup(user)
     shutil.rmtree(upload_folder, ignore_errors=True)
 

--- a/tests/test_sliced_file_upload.py
+++ b/tests/test_sliced_file_upload.py
@@ -358,6 +358,50 @@ def test_a_replayed_finalize_upload_returns_the_first_call_s_recording():
     shutil.rmtree(upload_folder, ignore_errors=True)
 
 
+def test_an_interrupted_sliced_upload_resumes_from_the_slices_already_sent():
+    """What the client needs to resume: the status endpoint has to say the
+    session is a sliced upload of this exact file and how many slices it
+    already holds, and the next slice has to pick up from there."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_resume")
+        client = app.test_client()
+        _login(client, user)
+
+        payload = _payload(SLICE_BYTES * 3)
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg",
+                                   total_bytes=len(payload))["session_id"]
+        _send_slices(client, session_id, payload[:SLICE_BYTES])
+
+        status = client.get(f"/upload/session/{session_id}").get_json()
+        assert status["kind"] == "sliced_upload"
+        assert status["upload_total_bytes"] == len(payload)
+        assert status["status"] == "recording"
+        assert status["chunk_count"] == 1
+
+        for index in (2, 3):
+            start = (index - 1) * SLICE_BYTES
+            resumed = client.post(
+                f"/upload/session/{session_id}/chunks/{index}",
+                data=payload[start:start + SLICE_BYTES],
+                content_type="application/octet-stream",
+            )
+            assert resumed.status_code == 204, (index, resumed.data)
+
+        staging = os.path.join(upload_folder, f"stg_{uuid.uuid4().hex[:6]}")
+        with _upload_mocks(staging):
+            response = client.post(f"/upload/session/{session_id}/finalize-upload",
+                                   data={}, content_type="multipart/form-data")
+
+        assert response.status_code == 202, response.data
+        recording = db.session.get(Recording, response.get_json()["id"])
+        assert recording.file_hash == hashlib.sha256(payload).hexdigest()
+
+        _cleanup(recording, user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
 def test_another_user_cannot_finalize_someone_elses_sliced_upload():
     upload_folder = _tmp_upload_folder()
     with app.app_context():

--- a/tests/test_sliced_file_upload.py
+++ b/tests/test_sliced_file_upload.py
@@ -1,0 +1,305 @@
+"""End-to-end tests for sliced uploads of files already on disk.
+
+A sliced upload reuses the recording-session endpoints to carry a file in
+fixed-size byte slices past a reverse proxy whose body limit is below the
+file size, then finalizes through /finalize-upload, which byte-joins the
+slices and runs them through the same ingestion pipeline POST /upload
+uses.
+
+The external effects of that pipeline (codec probe, conversion, storage,
+job queue) are mocked with the harness the /upload tests already use, so
+these tests assert the parts that are specific to slicing: the session is
+recognisable as a file upload, the reassembled bytes are the original
+bytes, the recorder's stitch path is kept away from them, and an
+abandoned one is expired rather than assembled into a truncated
+recording.
+"""
+
+import hashlib
+import os
+import shutil
+import sys
+import tempfile
+import uuid
+from datetime import datetime, timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.app import app, db
+from src.models import Recording, RecordingSession
+from src.api.recording_sessions import cleanup_expired_sessions
+
+from tests.test_cov_recordings_write import _cleanup, _mk_user, _upload_mocks
+from tests.test_recording_sessions import _login
+
+app.config["WTF_CSRF_ENABLED"] = False
+
+SLICE_BYTES = 4096
+
+
+def _tmp_upload_folder():
+    return tempfile.mkdtemp(prefix="speakr-test-sliced-")
+
+
+def _payload(size):
+    return bytes(range(256)) * (size // 256) + b"\xab" * (size % 256)
+
+
+def _open_session(client, filename="talk.mp4", mime_type="video/mp4"):
+    response = client.post("/upload/session", json={"filename": filename, "mime_type": mime_type})
+    assert response.status_code == 201, response.data
+    return response.get_json()
+
+
+def _send_slices(client, session_id, payload, slice_bytes=SLICE_BYTES):
+    for index, start in enumerate(range(0, len(payload), slice_bytes), start=1):
+        response = client.post(
+            f"/upload/session/{session_id}/chunks/{index}",
+            data=payload[start:start + slice_bytes],
+            content_type="application/octet-stream",
+        )
+        assert response.status_code == 204, (index, response.data)
+
+
+def test_create_session_with_filename_marks_it_a_file_upload():
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_create")
+        client = app.test_client()
+        _login(client, user)
+
+        body = _open_session(client)
+        assert body["upload_filename"] == "talk.mp4"
+        assert db.session.get(RecordingSession, body["session_id"]).upload_filename == "talk.mp4"
+
+        client.delete(f"/upload/session/{body['session_id']}")
+        _cleanup(user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_create_session_with_filename_skips_the_recorder_mime_whitelist():
+    """A user's own file can be any container ffmpeg reads, so the whitelist
+    that guards the recorder's stitch path must not gate these sessions."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_mime")
+        client = app.test_client()
+        _login(client, user)
+
+        rejected = client.post("/upload/session", json={"mime_type": "video/x-matroska"})
+        assert rejected.status_code == 400
+
+        accepted = _open_session(client, filename="lecture.mkv", mime_type="video/x-matroska")
+        assert accepted["mime_type"] == "video/x-matroska"
+
+        client.delete(f"/upload/session/{accepted['session_id']}")
+        _cleanup(user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_finalize_upload_ingests_the_reassembled_original_bytes():
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_ingest")
+        client = app.test_client()
+        _login(client, user)
+
+        payload = _payload(SLICE_BYTES * 3 + 17)
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        _send_slices(client, session_id, payload)
+
+        staging = os.path.join(upload_folder, f"stg_{uuid.uuid4().hex[:6]}")
+        with _upload_mocks(staging) as (storage, enqueue):
+            response = client.post(
+                f"/upload/session/{session_id}/finalize-upload",
+                data={"title": "Sliced", "notes": "n"},
+                content_type="multipart/form-data",
+            )
+
+        assert response.status_code == 202, response.data
+        recording = db.session.get(Recording, response.get_json()["id"])
+        assert recording.title == "Sliced"
+        assert recording.original_filename == "sample.mp3"
+        assert recording.file_hash == hashlib.sha256(payload).hexdigest()
+        assert enqueue.called
+
+        session = db.session.get(RecordingSession, session_id)
+        assert session.status == "finalized"
+        assert session.finalized_recording_id == recording.id
+        assert not os.path.isdir(os.path.join(upload_folder, "_sessions", session_id))
+
+        _cleanup(recording, user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_finalize_upload_carries_the_upload_form_through_ingestion():
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_form")
+        client = app.test_client()
+        _login(client, user)
+
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        _send_slices(client, session_id, _payload(SLICE_BYTES * 2))
+
+        staging = os.path.join(upload_folder, f"stg_{uuid.uuid4().hex[:6]}")
+        with _upload_mocks(staging) as (storage, enqueue):
+            response = client.post(
+                f"/upload/session/{session_id}/finalize-upload",
+                data={"language": "fr", "min_speakers": "2", "max_speakers": "4"},
+                content_type="multipart/form-data",
+            )
+
+        assert response.status_code == 202, response.data
+        params = enqueue.call_args.kwargs["params"]
+        assert params["language"] == "fr"
+        assert params["min_speakers"] == 2
+        assert params["max_speakers"] == 4
+
+        _cleanup(db.session.get(Recording, response.get_json()["id"]), user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_finalize_upload_rejects_a_slice_count_that_disagrees_with_disk():
+    """A slice lost between the write and the bookkeeping commit would
+    otherwise be silently ingested as a truncated file."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_short")
+        client = app.test_client()
+        _login(client, user)
+
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        _send_slices(client, session_id, _payload(SLICE_BYTES * 2))
+        os.remove(os.path.join(upload_folder, "_sessions", session_id, "chunk-000002.bin"))
+
+        response = client.post(
+            f"/upload/session/{session_id}/finalize-upload",
+            data={},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 409
+        assert response.get_json()["expected_chunk_index"] == 2
+
+        client.delete(f"/upload/session/{session_id}")
+        _cleanup(user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_the_two_finalize_routes_reject_each_others_sessions():
+    """The recorder's finalize remuxes and sniffs container headers per
+    chunk, which would rewrite or mis-split a byte-sliced file; the sliced
+    finalize skips the stitch a paused recording needs."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_routes")
+        client = app.test_client()
+        _login(client, user)
+
+        file_session = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        _send_slices(client, file_session, _payload(SLICE_BYTES))
+        stitch_refusal = client.post(f"/upload/session/{file_session}/finalize", json={})
+        assert stitch_refusal.status_code == 409
+        assert "finalize-upload" in stitch_refusal.get_json()["error"]
+
+        recorder_session = client.post(
+            "/upload/session", json={"mime_type": "audio/webm"}).get_json()["session_id"]
+        client.post(f"/upload/session/{recorder_session}/chunks/1",
+                    data=b"\x00" * 64, content_type="application/octet-stream")
+        upload_refusal = client.post(
+            f"/upload/session/{recorder_session}/finalize-upload",
+            data={}, content_type="multipart/form-data")
+        assert upload_refusal.status_code == 409
+        assert "/finalize" in upload_refusal.get_json()["error"]
+
+        client.delete(f"/upload/session/{file_session}")
+        client.delete(f"/upload/session/{recorder_session}")
+        _cleanup(user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_cleanup_expires_an_abandoned_sliced_upload_instead_of_assembling_it():
+    """Abandoned recorder sessions are auto-finalized because the browser
+    holds the only copy of that audio. A sliced upload's original is still
+    on the user's disk, and its slices are a truncated container, so
+    assembling one would land a broken recording in the library."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_expire")
+        client = app.test_client()
+        _login(client, user)
+
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        _send_slices(client, session_id, _payload(SLICE_BYTES))
+
+        session = db.session.get(RecordingSession, session_id)
+        session.last_seen_at = datetime.utcnow() - timedelta(hours=48)
+        db.session.commit()
+
+        cleanup_expired_sessions(app)
+
+        db.session.expire_all()
+        assert db.session.get(RecordingSession, session_id).status == "expired"
+        assert not os.path.isdir(os.path.join(upload_folder, "_sessions", session_id))
+        assert Recording.query.filter_by(user_id=user.id).count() == 0
+
+        _cleanup(user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_a_replayed_finalize_upload_does_not_ingest_the_file_twice():
+    """Finalize is synchronous, so a client that retries it after a lost
+    response would otherwise land the same file in the library twice."""
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        user = _mk_user("slice_replay")
+        client = app.test_client()
+        _login(client, user)
+
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        _send_slices(client, session_id, _payload(SLICE_BYTES))
+
+        staging = os.path.join(upload_folder, f"stg_{uuid.uuid4().hex[:6]}")
+        with _upload_mocks(staging):
+            first = client.post(f"/upload/session/{session_id}/finalize-upload",
+                                data={}, content_type="multipart/form-data")
+            second = client.post(f"/upload/session/{session_id}/finalize-upload",
+                                 data={}, content_type="multipart/form-data")
+
+        assert first.status_code == 202, first.data
+        assert second.status_code == 409
+        assert Recording.query.filter_by(user_id=user.id).count() == 1
+
+        _cleanup(db.session.get(Recording, first.get_json()["id"]), user)
+    shutil.rmtree(upload_folder, ignore_errors=True)
+
+
+def test_another_user_cannot_finalize_someone_elses_sliced_upload():
+    upload_folder = _tmp_upload_folder()
+    with app.app_context():
+        app.config["UPLOAD_FOLDER"] = upload_folder
+        owner = _mk_user("slice_owner")
+        intruder = _mk_user("slice_intruder")
+        client = app.test_client()
+        _login(client, owner)
+        session_id = _open_session(client, filename="sample.mp3", mime_type="audio/mpeg")["session_id"]
+        _send_slices(client, session_id, _payload(SLICE_BYTES))
+
+        other = app.test_client()
+        _login(other, intruder)
+        response = other.post(
+            f"/upload/session/{session_id}/finalize-upload",
+            data={}, content_type="multipart/form-data")
+        assert response.status_code == 404
+
+        client.delete(f"/upload/session/{session_id}")
+        _cleanup(owner, intruder)
+    shutil.rmtree(upload_folder, ignore_errors=True)


### PR DESCRIPTION
## Summary

A disk file upload is one multipart `POST /upload` of the whole file, so any reverse proxy with a request-body limit below the file size rejects it before Speakr sees it. Cloudflare caps bodies at 100 MB on most plans, which is well under a normal two-hour recording, and the only workaround today is to route uploads around the proxy. This sends files past a threshold as fixed-size byte slices through the existing recording-session endpoints, reassembles them server-side, and hands the result to the same ingestion function `POST /upload` uses. Same response, same recording, byte-identical file.

Speakr's two existing "chunking" features do not cover this, which is why the work exists:

- `src/audio_chunking.py` splits audio to fit an ASR provider's payload limit, after the file is already on the server. A request that got a 413 at the edge never reaches it.
- `ENABLE_SERVER_RECORDING_CHUNKS` (#287 c/d) streams MediaRecorder timeslices, only from the in-app recorder, and is off by default.

## User flow

1. User adds a file in the upload modal. Files over the slice size take the sliced transport, everything else is untouched.
2. The progress bar behaves as before: it moves within a slice, not only between slices.
3. On success the modal gets the same payload `POST /upload` returns, so the recording appears exactly as it does today.
4. Network drops mid-upload: re-adding the same file continues from the slice count the server reports, rather than restarting the transfer.
5. The edge times out the finalize request: the client waits out the ingest already running server-side and picks up its recording instead of reporting a failure.
6. A rejection the server will repeat (oversize slice, exhausted quota, size mismatch) fails the upload and deletes the half-sent session.

## Behavior changes

| | Before | After |
|---|---|---|
| Disk upload transport | one multipart POST of the whole file | slices of `max_chunk_bytes` (16 MB default) for files above that size, single-shot below |
| File larger than the proxy body limit | 413 from the proxy, upload impossible | uploads normally |
| Interrupted large upload | starts over | resumes from the slices the server holds |
| Lost finalize response | upload lost, file must be re-sent | replayed, same recording returned |
| `RecordingSession` rows | recorder sessions only | `kind` distinguishes `recorder` from `sliced_upload` |
| TTL sweep of an abandoned session | auto-finalizes what was recorded | sliced uploads expire instead, the user still has the original |

## Implementation notes

The session machinery (create, chunk POST, abort, quota, TTL sweep) is reused as is. What is new is one column set, one endpoint, and a client transport.

- **Model.** `kind` (`recorder` / `sliced_upload`, indexed), `upload_filename`, `upload_total_bytes` on `recording_session`. `kind` is what routes a session, not the presence of a filename.
- **`POST /upload/session`** takes `{filename, total_bytes}` to open a sliced upload. The recorder MIME whitelist is not applied to those: the user picks the container and ffprobe gates it at ingest.
- **`POST /upload/session/{id}/finalize-upload`** takes the `POST /upload` form minus the file part, byte-joins the slices, and calls `ingest_uploaded_recording` with a `FileStorage` subclass over the joined file whose `save` moves rather than copies. Ingestion is therefore unmodified, and the sliced path inherits hash and duplicate detection, the storage service (S3/R2), `convert_if_needed`, the size policy, video handling and the real `meeting_date` for free. The two finalize routes reject each other's sessions.
- **Why finalize is synchronous.** Reusing the recorder's async `/finalize` would have meant reimplementing all of the above inside a stitch worker. Holding the connection for the ingest is the cost of reusing the real ingestion path, and the client is built to survive the edge timing that out.
- **No stitching.** `recording_stitch.py` sniffs container headers per chunk and remuxes with ffmpeg, which is correct for MediaRecorder timeslices and corrupting for a byte slice of a complete file. Only its `session_chunk_paths` and `byte_join` helpers are used, exposed in a preparatory commit.
- **Client** (`static/js/modules/db/sliced-file-upload.js`): slices are `Blob` views, so a multi-gigabyte upload costs one slice of buffering. XHR rather than fetch for intra-slice progress. It does not reuse `server-recording-sessions.js`'s create/abort, which maintain the recorder's crash-recovery marker that a file upload must not touch. `upload.js` picks the transport and shares everything below it.

## Design decisions

- **Threshold, not a feature flag.** Slicing above 16 MB is correct behind a proxy and harmless without one, and a flag defaulted off would leave the reported problem in place for everyone who does not read the changelog. Happy to gate it if you would rather ship it opt-in.
- **Slice size follows `RECORDING_SESSION_MAX_CHUNK_BYTES`.** The create response is authoritative, so lowering that env var lowers the slice size with it. No second knob.
- **An abandoned sliced upload expires rather than being assembled.** Its slices are a truncated container, not a playable partial recording, and the original file is still on the user's disk.

## Data and rollout

- Additive columns in one `_migration_section`, all through `add_column_if_not_exists`: `kind` (`VARCHAR(20) DEFAULT 'recorder'`), `upload_filename` (`VARCHAR(255)`), `upload_total_bytes` (`BIGINT`). No backfill, no table rebuild, existing rows read as recorder sessions.
- New env var `RECORDING_SESSION_INGEST_HEARTBEAT_SECONDS` (default 30). No other configuration.
- Deploying mid-ingest interrupts that upload. The user's retry takes the session over after three missed heartbeats rather than waiting for the TTL sweep.
- Docs: `docs/features.md`, `docs/admin-guide/recording-sessions.md` (session kinds, env vars, on-disk layout, operational notes, endpoint table).

## Risks and edge cases

The core transport was two commits. The remaining seven are failure modes found across three review rounds, which is the expected ratio for an upload path that has to survive a flaky connection and a proxy in front of it.

| Failure mode | Behavior |
|---|---|
| `RECORDING_SESSION_COMMIT_BATCH_SIZE > 1` makes the server report a stale chunk count | bounded resyncs, then the upload fails, instead of the client asking for the same index forever |
| Reassembly fails (full disk) | session marked failed and its slices reclaimed, so the file does not leak until an operator notices |
| A slice is short or missing | joined size is checked against `total_bytes` at finalize, refused rather than ingested truncated |
| A slice POST in flight during finalize | the session is claimed before its directory is listed, so the ingested file cannot be a prefix |
| Client loses the finalize response | replayed from `finalized_recording_id`, same recording, `idempotent_replay: true` |
| Edge returns 524 on the finalize | treated as inconclusive, the client polls the session and adopts the ingest's recording |
| Status endpoint itself failing during the wait | keeps polling, gives up only when the server says the session is gone |
| Worker killed mid-ingest (container recreated) | the ingest heartbeats on the row, three missed beats make the session claimable again |
| `--timeout` under `gthread` | does not bound request duration, so liveness is reported by the ingest rather than inferred from a clock. This corrects a premise the first version relied on. |
| Abort during ingest | refused with 409, its slices are being read in-request |
| TTL sweep racing a resumed upload | expiry claims the row conditionally, a session that came back to life keeps its files |

## Tests

Full suite green locally: `pytest tests/ -q` gives 1751 passed, 8 skipped (Python 3.11 container, ffmpeg installed), `npm test` gives 249 passed.

- `tests/test_sliced_file_upload.py` (16 tests): create semantics, byte-identical ingestion of the original file, form pass-through, size-mismatch refusal, slice reclamation on failure, abort refusal during ingest, cross-route rejection, TTL expiry, finalize replay, resume, heartbeat stamping, a late stamp not reviving a finished session, takeover after a dead worker, cross-user ownership, and a recorder session surviving the migration.
- `static/js/modules/db/sliced-file-upload.test.js` (28 tests): threshold, ordered whole slices, server-supplied slice size, network retry, 409 skip-ahead, stalled-resync bound, bare 413 attribution, CSRF refresh, a server without sliced-upload support, finalize errors, and the full resume and ingest-wait matrix.
- `tests/test_recording_stitch.py` updated for the exposed helpers.
